### PR TITLE
Fix first-run installer abort on macOS bash 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ this project uses [Semantic Versioning](https://semver.org/).
 - Reset-aware routing that prioritizes weekly quota at risk of expiring and
   gives a bounded boost to subscriptions with banked usage resets.
 
+### Fixed
+
+- Empty `patch_arguments` expansion in `install.sh` under bash 3.2 `set -u`.
+
 ## [0.1.0] - 2026-08-15
 
 ### Added

--- a/install.sh
+++ b/install.sh
@@ -134,7 +134,12 @@ main() {
     fi
 
     log "Building and signing Codex Subscription Router"
-    python3 scripts/patch_app.py "${patch_arguments[@]}"
+    # macOS /bin/bash is 3.2; set -u treats "${empty[@]}" as unbound.
+    if [ "${#patch_arguments[@]}" -ne 0 ]; then
+        python3 scripts/patch_app.py "${patch_arguments[@]}"
+    else
+        python3 scripts/patch_app.py
+    fi
 
     log "Launching Codex Subscription Router"
     open "${DESTINATION_APP}"

--- a/install.sh
+++ b/install.sh
@@ -134,7 +134,7 @@ main() {
     fi
 
     log "Building and signing Codex Subscription Router"
-    # macOS /bin/bash is 3.2; set -u treats "${empty[@]}" as unbound.
+    # macOS /bin/bash is 3.2; with set -u, expanding an empty array (e.g. "${patch_arguments[@]}") errors as “unbound variable”.
     if [ "${#patch_arguments[@]}" -ne 0 ]; then
         python3 scripts/patch_app.py "${patch_arguments[@]}"
     else


### PR DESCRIPTION
## Summary

- `install.sh` now checks `${#patch_arguments[@]}` before expanding the array, same as `missing` a few lines above. On macOS `/bin/bash` 3.2, `set -u` treats `"${empty[@]}"` as unbound.
- That is the documented `curl | /bin/bash` first-install path. It was stopping after `npm ci` with `patch_arguments[@]: unbound variable`.

Fixes #16.

## Verification

- [x] `npm run check`
- [x] `npm run release:check`
- [ ] Tested against the upstream build in `docs/COMPATIBILITY.md`
- [x] No credentials, account data, app bundles, or unredacted device codes

I did not run `patch_app.py`. Under `/bin/bash` 3.2.57 the old expansion aborts; the length check runs `python3 -c 'import sys; print(sys.argv)'` as `['-c']` with an empty array and `['-c', '--force']` after `+=("--force")`.

## Security-sensitive changes

None. First install still invokes `python3 scripts/patch_app.py` with no extra args. Reinstall still passes `--force`.
