### PR TITLE
Strip aps-environment so ad-hoc copies can launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ this project uses [Semantic Versioning](https://semver.org/).
 - Reset-aware routing that prioritizes weekly quota at risk of expiring and
   gives a bounded boost to subscriptions with banked usage resets.
 
+### Fixed
+
+- Ad-hoc and non-OpenAI signatures no longer keep `aps-environment`, which
+  made AMFI kill the copied app at launch. First install now falls back to
+  ad-hoc when no signing certificate is present.
+
 ## [0.1.0] - 2026-08-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -89,10 +89,12 @@ is rejected by default rather than being partially patched. See
 - Xcode Command Line Tools
 - Go 1.26+
 - Node.js 22.12+ and npm
-- An Apple Development or Developer ID Application signing identity
+- Optional: an Apple Development or Developer ID Application signing identity
 
-A team-backed signing identity is required for reliable Appshots and Computer
-Use permissions. Ad-hoc signing is intended only for diagnostics.
+A team-backed signing identity is used when one is present so Appshots and
+Computer Use keep stable privacy grants. If none exists, the patcher signs
+ad-hoc automatically. Restricted OpenAI entitlements such as push
+(`aps-environment`) are stripped so AMFI will still launch the copy.
 
 ## Install
 
@@ -135,8 +137,9 @@ This creates:
 - an independent desktop profile under
   `~/Library/Application Support/Codex Subscription Router`
 
-The first valid Developer ID Application identity is selected, falling back to
-an Apple Development identity. Select a certificate explicitly when needed:
+The first valid Developer ID Application identity is selected, then an Apple
+Development identity, then an ad-hoc signature. Select a certificate
+explicitly when needed:
 
 ```sh
 CODEX_MUX_SIGNING_IDENTITY="Developer ID Application: Example Corp (TEAMID1234)" \
@@ -148,13 +151,10 @@ designated requirement and can invalidate existing macOS privacy consent. The
 patcher refuses an unexpected team change unless you deliberately pass
 `--allow-signing-team-change`.
 
-For diagnostic builds without a certificate:
-
-```sh
-python3 scripts/patch_app.py --allow-adhoc-signing
-```
-
-Appshots and Computer Use may not function with an ad-hoc signature.
+`--allow-adhoc-signing` is accepted for compatibility. It is no longer
+required: a machine with no certificate already gets an ad-hoc build. Appshots
+and Computer Use may still fail helper peer checks without a team-backed
+identity.
 
 ## Grant macOS permissions
 

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -43,8 +43,11 @@ documented ChatGPT profile and rate-limit APIs.
 
 The source app is copied into a temporary staging directory. Native modules,
 the Computer Use helper, Node runtime, mux, and final app are signed under one
-selected Apple team and verified before replacement. Official OpenAI
-application-group and keychain entitlements are removed from modified callers.
+selected Apple team when available, otherwise ad-hoc, and verified before
+replacement. Official OpenAI application-group, keychain, and push
+(`aps-environment`) entitlements are removed from modified callers. Push is
+provisioned to OpenAI's team; leaving it on any other signature is a
+restricted-entitlement AMFI kill, including ad-hoc.
 
 The native helper's caller allowlist is patched to the selected team and the
 independent desktop bundle ID. This is required for the helper's peer checks;

--- a/scripts/patch_app.py
+++ b/scripts/patch_app.py
@@ -68,7 +68,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--allow-adhoc-signing",
         action="store_true",
-        help="Allow an ad-hoc signature (Appshots and Computer Use may stop working).",
+        help=(
+            "Accepted for compatibility. Ad-hoc signing is used automatically "
+            "when no Developer ID or Apple Development identity is found."
+        ),
     )
     parser.add_argument(
         "--allow-untested-source",
@@ -110,16 +113,17 @@ def resolve_signing_identity(allow_adhoc: bool) -> str:
         for identity in available:
             if identity.startswith(prefix):
                 return identity
-    if allow_adhoc:
-        print(
-            "Warning: using an ad-hoc signature; Appshots and Computer Use may be unavailable.",
-            file=sys.stderr,
-        )
-        return "-"
-    raise RuntimeError(
-        "no team-backed code-signing identity found; set CODEX_MUX_SIGNING_IDENTITY "
-        "or explicitly pass --allow-adhoc-signing"
+    # Ad-hoc is the first-install default. A missing Apple certificate must not
+    # block a launchable copy; restricted entitlements are stripped below so
+    # AMFI does not kill the process. Appshots/Computer Use still prefer a
+    # stable team-backed identity. `allow_adhoc` remains in the signature so
+    # existing `--allow-adhoc-signing` callers keep working.
+    print(
+        "Warning: no team-backed code-signing identity found; "
+        "using an ad-hoc signature. Appshots and Computer Use may be unavailable.",
+        file=sys.stderr,
     )
+    return "-"
 
 
 def signing_team_identifier(identity: str) -> str | None:
@@ -418,6 +422,10 @@ TEAM_SCOPED_ENTITLEMENTS = (
     "com.apple.developer.team-identifier",
     "com.apple.security.application-groups",
     "keychain-access-groups",
+    # Push is provisioned to OpenAI team 2DC432GLL2. Keeping it on an ad-hoc
+    # signature or any other team makes AMFI kill the process at exec
+    # (restricted entitlement, codesign still reports valid on disk).
+    "com.apple.developer.aps-environment",
 )
 
 


### PR DESCRIPTION
## Summary

- `sanitized_runtime_entitlements()` now drops `com.apple.developer.aps-environment` along with the other OpenAI team-scoped keys.
- Official ChatGPT ships `aps-environment=production` for team `2DC432GLL2`. Re-signing ad-hoc (or as any other team) while keeping that key is a restricted entitlement. AMFI SIGKILLs the process at exec. `codesign --verify --deep --strict` still says valid, so it looks like a crash with no ReportCrash.
- First install no longer requires `--allow-adhoc-signing` when no certificate exists. The flag still parses so old commands keep working.

Refs #5, entitlement/AMFI part only. Does not touch renderer anchors or the compatibility hash table.

## Verification

- [x] `npm run check`
- [x] `npm run release:check`
- [ ] Tested against the upstream build in `docs/COMPATIBILITY.md`
- [x] No credentials, account data, app bundles, or unredacted device codes

I did not run a full `patch_app.py` against the tested 26.803.61601 bundle (this machine has 26.818.41509). Proof is against a copy of the current `Contents/MacOS/ChatGPT` in a temp dir; `/Applications/ChatGPT.app` was not modified.

| entitlements on ad-hoc copy | `codesign --verify --strict` | exec |
| --- | --- | --- |
| `aps-environment=production` kept | valid | SIGKILL, exit 137, empty stderr |
| `aps-environment` stripped | valid | AMFI lets it run; then dyld abort 134 looking for Codex Framework (expected, it is not a full app) |

`resolve_signing_identity(False)` returns `-` here because `security find-identity -p codesigning` has 0 identities.

## Security-sensitive changes

Signing: strip OpenAI's push entitlement on re-sign so a non-OpenAI signature can launch. Computer Use helper peer checks still want a team-backed identity. This PR does not claim Appshots or Computer Use work ad-hoc.