### PR TITLE
Add auth.json import for secondary subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ this project uses [Semantic Versioning](https://semver.org/).
   rebuilds, recoverable upgrades, and automatic launch.
 - Reset-aware routing that prioritizes weekly quota at risk of expiring and
   gives a bounded boost to subscriptions with banked usage resets.
+- Native `auth.json` import for secondary ChatGPT subscriptions, with strict
+  shape validation, duplicate-account protection, private atomic writes, and
+  first-start app-server verification.
 
 ## [0.1.0] - 2026-08-15
 

--- a/README.md
+++ b/README.md
@@ -176,13 +176,26 @@ request Automation access the first time Computer Use controls another app.
 
 ## Add subscriptions
 
-1. Open the profile menu at the bottom of the sidebar.
-2. Select **Add another subscription**.
-3. Complete the displayed device-code sign-in in your browser.
-4. Return to Codex Subscription Router and wait for the account row to appear.
+Open the profile menu at the bottom of the sidebar and select **Add another
+subscription**, then choose one path:
+
+- Select **Continue with ChatGPT** and complete the displayed device-code
+  sign-in in your browser.
+- Select **Import auth.json** and choose an existing, native Codex ChatGPT login
+  file. The file is sent only to the token-authenticated loopback service,
+  validated, and written to the new account's isolated Codex home before its
+  app-server starts.
 
 While the code is visible, clicking away does not dismiss the menu. Clicking
 the code copies it and opens the verification page.
+
+The importer accepts only a refreshable ChatGPT shape: `auth_mode` must be
+`chatgpt`, `OPENAI_API_KEY` must be absent or null, and `access_token`,
+`refresh_token`, and `account_id` must be present. Files larger than 64 KiB,
+unknown fields, and duplicate account IDs (including Primary) are rejected.
+Imported credentials are atomically written with mode `0600`; tokens are never
+returned by the control API. Import is a Router feature, not an officially
+documented ChatGPT desktop login method.
 
 The profile menu displays combined weekly usage followed by one row per
 subscription. Email addresses remain masked until hovered. The final row always
@@ -280,6 +293,8 @@ latest completed run is recorded in
   because the upstream profile response exposes counts rather than skill IDs.
 - Generated app bundles are tied to one macOS user and signing team.
 - Releases are source-only; patched OpenAI binaries are never distributed.
+- Treat every `auth.json` as a password; never attach one to an issue, PR, log,
+  or screenshot.
 
 ## Contributing and releases
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,6 +36,10 @@ The Primary account uses `~/.codex`. Added accounts use
 `~/.codex-mux/accounts/<id>/codex-home`. Managed configuration is copied from
 the Primary account, excluding credential-store settings and project trust.
 Each isolated account forces file-backed CLI and MCP OAuth credentials.
+Accounts can authenticate through the official device-code RPC or by importing
+a complete native ChatGPT `auth.json` before the account child starts. Imported
+files are validated, duplicate `account_id` values are blocked, and token
+refresh remains owned by the official Codex child in that isolated home.
 
 ## Desktop integration
 

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -19,6 +19,13 @@ profile and rate-limit-reset endpoints used by the desktop experience. It does
 not log or return tokens. State persisted by the mux contains account paths,
 labels, enabled state, and thread ownership only.
 
+The optional import endpoint is loopback-only and control-token authenticated.
+It caps the request size, accepts only the known refreshable ChatGPT auth shape,
+rejects API keys and duplicate `account_id` values, and writes through a new
+mode-`0600` temporary file followed by atomic rename. The real app-server must
+then return a connected ChatGPT account. The selected file remains in browser
+memory only for that request; Router does not keep a second refresh-token copy.
+
 The state root is mode `0700`; state, config, and control-token files are mode
 `0600`. Existing control tokens are validated as 256-bit hexadecimal values and
 their permissions are repaired on startup.
@@ -33,7 +40,8 @@ shared plugin configuration.
 
 The control server binds to `127.0.0.1`. Private endpoints require the token
 embedded into the independently built local renderer. Profile images must use
-HTTPS. Response sizes and JSON request bodies are bounded.
+HTTPS. Response sizes and JSON request bodies, including auth imports, are
+bounded.
 
 The project itself does not provide a telemetry or update endpoint. Network
 traffic beyond loopback is performed by the official Codex children or by the

--- a/internal/backend/child.go
+++ b/internal/backend/child.go
@@ -151,7 +151,11 @@ func (c *Child) Stop(ctx context.Context) error {
 		return nil
 	}
 	if err := c.command.Process.Signal(os.Interrupt); err != nil && !errors.Is(err, os.ErrProcessDone) {
-		return err
+		if killErr := c.command.Process.Kill(); killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+			return errors.Join(err, killErr)
+		}
+		<-c.closed
+		return nil
 	}
 	select {
 	case <-c.closed:

--- a/internal/backend/child.go
+++ b/internal/backend/child.go
@@ -143,6 +143,28 @@ func (c *Child) Close() error {
 	return c.command.Process.Signal(os.Interrupt)
 }
 
+// Stop interrupts the child and waits for it to exit. If the graceful stop
+// does not finish before ctx expires, Stop kills the process and still waits
+// for Wait to release its resources.
+func (c *Child) Stop(ctx context.Context) error {
+	if c.command.Process == nil {
+		return nil
+	}
+	if err := c.command.Process.Signal(os.Interrupt); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return err
+	}
+	select {
+	case <-c.closed:
+		return nil
+	case <-ctx.Done():
+		if err := c.command.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			return err
+		}
+		<-c.closed
+		return nil
+	}
+}
+
 func (c *Child) readLoop(stdout io.Reader) {
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 64*1024), 64*1024*1024)

--- a/internal/control/import_auth.go
+++ b/internal/control/import_auth.go
@@ -1,0 +1,54 @@
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/b-nnett/codex-subscription-router/internal/state"
+)
+
+func (s *Server) importAccount(response http.ResponseWriter, request *http.Request) {
+	if !s.authorized(request) {
+		writeJSON(response, http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
+		return
+	}
+	if request.Method != http.MethodPost {
+		methodNotAllowed(response)
+		return
+	}
+	request.Body = http.MaxBytesReader(response, request.Body, state.MaxImportedAuthBytes+4096)
+	var input struct {
+		Label string          `json:"label"`
+		Auth  json.RawMessage `json:"auth"`
+	}
+	decoder := json.NewDecoder(request.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&input); err != nil {
+		writeJSON(response, http.StatusBadRequest, map[string]any{"error": "invalid auth.json import request"})
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		writeJSON(response, http.StatusBadRequest, map[string]any{"error": "invalid trailing import data"})
+		return
+	}
+	if len(input.Auth) == 0 {
+		writeJSON(response, http.StatusBadRequest, map[string]any{"error": "auth.json is required"})
+		return
+	}
+	ctx, cancel := context.WithTimeout(request.Context(), 45*time.Second)
+	defer cancel()
+	account, err := s.mux.ImportAccount(ctx, input.Label, input.Auth)
+	if err != nil {
+		status := http.StatusBadRequest
+		if errors.Is(err, state.ErrDuplicateChatGPTAccount) {
+			status = http.StatusConflict
+		}
+		writeJSON(response, status, map[string]any{"error": err.Error()})
+		return
+	}
+	writeJSON(response, http.StatusCreated, map[string]any{"account": account})
+}

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -25,6 +25,7 @@ func New(address, token string, multiplexer *mux.Multiplexer, uiTests bool) *Ser
 	server := &Server{token: token, mux: multiplexer, uiTests: uiTests}
 	router := http.NewServeMux()
 	router.HandleFunc("/v1/health", server.health)
+	router.HandleFunc("/v1/accounts/import", server.importAccount)
 	router.HandleFunc("/v1/accounts", server.accounts)
 	router.HandleFunc("/v1/accounts/", server.accountAction)
 	router.HandleFunc("/v1/thread-account", server.threadAccount)

--- a/internal/mux/import_auth.go
+++ b/internal/mux/import_auth.go
@@ -1,0 +1,27 @@
+package mux
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+func (m *Multiplexer) ImportAccount(ctx context.Context, label string, authJSON json.RawMessage) (AccountSnapshot, error) {
+	account, err := m.store.AddAccountWithAuth(label, authJSON)
+	if err != nil {
+		return AccountSnapshot{}, err
+	}
+	if _, err := m.startChild(ctx, account); err != nil {
+		return AccountSnapshot{}, fmt.Errorf("start imported account: %w", err)
+	}
+	snapshot, err := m.accountSnapshotWithProfile(ctx, account.ID, false)
+	if err != nil {
+		return AccountSnapshot{}, fmt.Errorf("verify imported account: %w", err)
+	}
+	if !snapshot.Connected || snapshot.AuthType != "chatgpt" {
+		return AccountSnapshot{}, errors.New("imported auth.json did not produce a ChatGPT login")
+	}
+	m.publish(Event{Type: "account-updated", AccountID: account.ID, Data: snapshot})
+	return snapshot, nil
+}

--- a/internal/mux/import_auth.go
+++ b/internal/mux/import_auth.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
+
+	"github.com/b-nnett/codex-subscription-router/internal/state"
 )
 
 func (m *Multiplexer) ImportAccount(ctx context.Context, label string, authJSON json.RawMessage) (AccountSnapshot, error) {
@@ -13,15 +16,38 @@ func (m *Multiplexer) ImportAccount(ctx context.Context, label string, authJSON 
 		return AccountSnapshot{}, err
 	}
 	if _, err := m.startChild(ctx, account); err != nil {
-		return AccountSnapshot{}, fmt.Errorf("start imported account: %w", err)
+		return AccountSnapshot{}, m.rollbackImportedAccount(account, fmt.Errorf("start imported account: %w", err))
 	}
 	snapshot, err := m.accountSnapshotWithProfile(ctx, account.ID, false)
 	if err != nil {
-		return AccountSnapshot{}, fmt.Errorf("verify imported account: %w", err)
+		return AccountSnapshot{}, m.rollbackImportedAccount(account, fmt.Errorf("verify imported account: %w", err))
 	}
 	if !snapshot.Connected || snapshot.AuthType != "chatgpt" {
-		return AccountSnapshot{}, errors.New("imported auth.json did not produce a ChatGPT login")
+		return AccountSnapshot{}, m.rollbackImportedAccount(account, errors.New("imported auth.json did not produce a ChatGPT login"))
 	}
 	m.publish(Event{Type: "account-updated", AccountID: account.ID, Data: snapshot})
 	return snapshot, nil
+}
+
+func (m *Multiplexer) rollbackImportedAccount(account state.Account, cause error) error {
+	m.childrenMu.Lock()
+	child := m.children[account.ID]
+	delete(m.children, account.ID)
+	m.childrenMu.Unlock()
+
+	var cleanupErrors []error
+	if child != nil {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := child.Stop(stopCtx); err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("stop child: %w", err))
+		}
+		cancel()
+	}
+	if err := m.store.DiscardImportedAccount(account.ID); err != nil {
+		cleanupErrors = append(cleanupErrors, err)
+	}
+	if len(cleanupErrors) > 0 {
+		return fmt.Errorf("%w; rollback failed: %v", cause, errors.Join(cleanupErrors...))
+	}
+	return cause
 }

--- a/internal/mux/import_auth_test.go
+++ b/internal/mux/import_auth_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -34,7 +35,7 @@ func TestImportAccountAuthenticatesOnFirstChildStart(t *testing.T) {
 	multiplexer, err := New(Options{
 		RealExecutable: os.Args[0],
 		RealArgs:       []string{"-test.run=TestImportedAuthHelperProcess"},
-		Environment:    append(os.Environ(), "CODEX_MUX_AUTH_HELPER=1"),
+		Environment:    append(os.Environ(), "CODEX_MUX_AUTH_HELPER=connected"),
 		Store:          store,
 		Output:         io.Discard,
 	})
@@ -64,8 +65,82 @@ func TestImportAccountAuthenticatesOnFirstChildStart(t *testing.T) {
 	}
 }
 
+func TestImportAccountRollsBackStartupAndVerificationFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		executable string
+		helperMode string
+		initialize bool
+	}{
+		{name: "process start", executable: "missing-app-server"},
+		{name: "initialize", executable: os.Args[0], helperMode: "initialize-error", initialize: true},
+		{name: "disconnected verification", executable: os.Args[0], helperMode: "disconnected"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			store, err := state.Open(filepath.Join(root, "mux"), filepath.Join(root, "primary"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			executable := test.executable
+			args := []string(nil)
+			environment := os.Environ()
+			if test.helperMode != "" {
+				args = []string{"-test.run=TestImportedAuthHelperProcess"}
+				environment = append(environment, "CODEX_MUX_AUTH_HELPER="+test.helperMode)
+			} else {
+				executable = filepath.Join(root, executable)
+			}
+			multiplexer, err := New(Options{
+				RealExecutable: executable,
+				RealArgs:       args,
+				Environment:    environment,
+				Store:          store,
+				Output:         io.Discard,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer multiplexer.Close()
+			if test.initialize {
+				multiplexer.initializeParams = json.RawMessage(`{"clientInfo":{"name":"test"}}`)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if _, err := multiplexer.ImportAccount(ctx, "Rejected", json.RawMessage(importedAuthFixture)); err == nil {
+				t.Fatal("failed import unexpectedly succeeded")
+			}
+			if accounts := store.Accounts(); len(accounts) != 1 || accounts[0].ID != "primary" {
+				t.Fatalf("accounts after rollback = %#v", accounts)
+			}
+			multiplexer.childrenMu.RLock()
+			childCount := len(multiplexer.children)
+			multiplexer.childrenMu.RUnlock()
+			if childCount != 0 {
+				t.Fatalf("child count after rollback = %d, want 0", childCount)
+			}
+			entries, err := os.ReadDir(filepath.Join(store.Root(), "accounts"))
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
+				t.Fatal(err)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("account resources remain after rollback: %v", entries)
+			}
+			reopened, err := state.Open(store.Root(), filepath.Join(root, "primary"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if accounts := reopened.Accounts(); len(accounts) != 1 || accounts[0].ID != "primary" {
+				t.Fatalf("persisted accounts after rollback = %#v", accounts)
+			}
+		})
+	}
+}
+
 func TestImportedAuthHelperProcess(t *testing.T) {
-	if os.Getenv("CODEX_MUX_AUTH_HELPER") != "1" {
+	mode := os.Getenv("CODEX_MUX_AUTH_HELPER")
+	if mode == "" {
 		return
 	}
 	scanner := bufio.NewScanner(os.Stdin)
@@ -79,10 +154,19 @@ func TestImportedAuthHelperProcess(t *testing.T) {
 			continue
 		}
 		result := any(map[string]any{})
+		if request.Method == "initialize" && mode == "initialize-error" {
+			_ = encoder.Encode(map[string]any{
+				"jsonrpc": "2.0", "id": request.ID,
+				"error": map[string]any{"code": -32000, "message": "initialize rejected"},
+			})
+			continue
+		}
 		switch request.Method {
 		case "account/read":
 			authPath := filepath.Join(os.Getenv("CODEX_HOME"), "auth.json")
-			if _, err := os.Stat(authPath); err != nil {
+			if mode == "disconnected" {
+				result = map[string]any{"account": nil}
+			} else if _, err := os.Stat(authPath); err != nil {
 				result = map[string]any{"account": nil}
 			} else {
 				result = map[string]any{"account": map[string]any{

--- a/internal/mux/import_auth_test.go
+++ b/internal/mux/import_auth_test.go
@@ -1,0 +1,100 @@
+package mux
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/b-nnett/codex-subscription-router/internal/state"
+)
+
+const importedAuthFixture = `{
+  "auth_mode": "chatgpt",
+  "OPENAI_API_KEY": null,
+  "tokens": {
+    "id_token": "id-token-test",
+    "access_token": "access-token-test",
+    "refresh_token": "refresh-token-test",
+    "account_id": "account-import-test"
+  },
+  "last_refresh": "2026-08-24T00:00:00Z"
+}`
+
+func TestImportAccountAuthenticatesOnFirstChildStart(t *testing.T) {
+	root := t.TempDir()
+	store, err := state.Open(filepath.Join(root, "mux"), filepath.Join(root, "primary"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	multiplexer, err := New(Options{
+		RealExecutable: os.Args[0],
+		RealArgs:       []string{"-test.run=TestImportedAuthHelperProcess"},
+		Environment:    append(os.Environ(), "CODEX_MUX_AUTH_HELPER=1"),
+		Store:          store,
+		Output:         io.Discard,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer multiplexer.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	snapshot, err := multiplexer.ImportAccount(ctx, "Imported", json.RawMessage(importedAuthFixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !snapshot.Connected || snapshot.AuthType != "chatgpt" || snapshot.PlanLabel != "Plus" {
+		t.Fatalf("unexpected imported account snapshot: %#v", snapshot)
+	}
+	account, ok := store.Account(snapshot.ID)
+	if !ok {
+		t.Fatalf("imported account %q missing from store", snapshot.ID)
+	}
+	info, err := os.Stat(filepath.Join(account.CodexHome, "auth.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("auth.json mode = %#o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestImportedAuthHelperProcess(t *testing.T) {
+	if os.Getenv("CODEX_MUX_AUTH_HELPER") != "1" {
+		return
+	}
+	scanner := bufio.NewScanner(os.Stdin)
+	encoder := json.NewEncoder(os.Stdout)
+	for scanner.Scan() {
+		var request struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if json.Unmarshal(scanner.Bytes(), &request) != nil {
+			continue
+		}
+		result := any(map[string]any{})
+		switch request.Method {
+		case "account/read":
+			authPath := filepath.Join(os.Getenv("CODEX_HOME"), "auth.json")
+			if _, err := os.Stat(authPath); err != nil {
+				result = map[string]any{"account": nil}
+			} else {
+				result = map[string]any{"account": map[string]any{
+					"type": "chatgpt", "email": "import@example.com", "planType": "plus",
+				}}
+			}
+		case "account/rateLimits/read":
+			result = map[string]any{"rateLimits": map[string]any{
+				"primary": map[string]any{"usedPercent": 10},
+			}}
+		}
+		_ = encoder.Encode(map[string]any{"jsonrpc": "2.0", "id": request.ID, "result": result})
+	}
+	os.Exit(0)
+}

--- a/internal/state/auth.go
+++ b/internal/state/auth.go
@@ -1,0 +1,159 @@
+package state
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const MaxImportedAuthBytes = 64 * 1024
+
+var ErrDuplicateChatGPTAccount = errors.New("ChatGPT account is already configured")
+
+type importedAuthDocument struct {
+	AuthMode     string          `json:"auth_mode"`
+	OpenAIAPIKey json.RawMessage `json:"OPENAI_API_KEY"`
+	Tokens       struct {
+		IDToken      *string `json:"id_token"`
+		AccessToken  string  `json:"access_token"`
+		RefreshToken string  `json:"refresh_token"`
+		AccountID    string  `json:"account_id"`
+	} `json:"tokens"`
+	LastRefresh *string `json:"last_refresh"`
+}
+
+func (s *Store) AddAccountWithAuth(label string, contents []byte) (Account, error) {
+	normalized, externalID, err := validateImportedAuth(contents)
+	if err != nil {
+		return Account{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, account := range s.accounts {
+		if authAccountID(filepath.Join(account.CodexHome, "auth.json")) == externalID {
+			return Account{}, ErrDuplicateChatGPTAccount
+		}
+	}
+	return s.addAccountLocked(label, normalized)
+}
+
+func validateImportedAuth(contents []byte) ([]byte, string, error) {
+	if len(contents) == 0 {
+		return nil, "", errors.New("auth.json is empty")
+	}
+	if len(contents) > MaxImportedAuthBytes {
+		return nil, "", fmt.Errorf("auth.json exceeds %d bytes", MaxImportedAuthBytes)
+	}
+	var auth importedAuthDocument
+	decoder := json.NewDecoder(bytes.NewReader(contents))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&auth); err != nil {
+		return nil, "", fmt.Errorf("decode auth.json: %w", err)
+	}
+	if err := ensureJSONEnd(decoder); err != nil {
+		return nil, "", err
+	}
+	if auth.AuthMode != "chatgpt" {
+		return nil, "", errors.New("auth.json auth_mode must be chatgpt")
+	}
+	if len(auth.OpenAIAPIKey) != 0 && string(bytes.TrimSpace(auth.OpenAIAPIKey)) != "null" {
+		return nil, "", errors.New("auth.json OPENAI_API_KEY must be null for a ChatGPT subscription")
+	}
+	for name, value := range map[string]string{
+		"access_token":  auth.Tokens.AccessToken,
+		"refresh_token": auth.Tokens.RefreshToken,
+		"account_id":    auth.Tokens.AccountID,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return nil, "", fmt.Errorf("auth.json tokens.%s must be a non-empty string", name)
+		}
+	}
+	if auth.Tokens.IDToken != nil {
+		if strings.TrimSpace(*auth.Tokens.IDToken) == "" {
+			return nil, "", errors.New("auth.json tokens.id_token must be a non-empty string when present")
+		}
+	}
+	if auth.LastRefresh != nil {
+		if strings.TrimSpace(*auth.LastRefresh) == "" {
+			return nil, "", errors.New("auth.json last_refresh must be a non-empty string when present")
+		}
+		if _, err := time.Parse(time.RFC3339Nano, *auth.LastRefresh); err != nil {
+			return nil, "", errors.New("auth.json last_refresh must use RFC 3339 format")
+		}
+	}
+	var normalized bytes.Buffer
+	if err := json.Indent(&normalized, bytes.TrimSpace(contents), "", "  "); err != nil {
+		return nil, "", fmt.Errorf("format auth.json: %w", err)
+	}
+	normalized.WriteByte('\n')
+	return normalized.Bytes(), strings.TrimSpace(auth.Tokens.AccountID), nil
+}
+
+func ensureJSONEnd(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); errors.Is(err, io.EOF) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("decode trailing auth.json content: %w", err)
+	}
+	return errors.New("auth.json contains more than one JSON value")
+}
+
+func authAccountID(path string) string {
+	info, err := os.Stat(path)
+	if err != nil || info.Size() > MaxImportedAuthBytes {
+		return ""
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	var auth struct {
+		AuthMode string `json:"auth_mode"`
+		Tokens   struct {
+			AccountID string `json:"account_id"`
+		} `json:"tokens"`
+	}
+	if json.Unmarshal(contents, &auth) != nil || auth.AuthMode != "chatgpt" {
+		return ""
+	}
+	return strings.TrimSpace(auth.Tokens.AccountID)
+}
+
+func atomicWritePrivate(path string, contents []byte) error {
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return err
+	}
+	temporary, err := os.CreateTemp(parent, ".auth.json.tmp-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0o600); err != nil {
+		temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(contents); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
+}

--- a/internal/state/auth.go
+++ b/internal/state/auth.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 )
@@ -92,7 +94,48 @@ func validateImportedAuth(contents []byte) ([]byte, string, error) {
 		return nil, "", fmt.Errorf("format auth.json: %w", err)
 	}
 	normalized.WriteByte('\n')
+	if normalized.Len() > MaxImportedAuthBytes {
+		return nil, "", fmt.Errorf("normalized auth.json exceeds %d bytes", MaxImportedAuthBytes)
+	}
 	return normalized.Bytes(), strings.TrimSpace(auth.Tokens.AccountID), nil
+}
+
+// DiscardImportedAccount removes a failed import from routing state and wipes
+// its generated account directory, including auth.json and any child-created
+// token or database material. It only accepts the exact account-home layout
+// created by addAccountLocked.
+func (s *Store) DiscardImportedAccount(id string) error {
+	s.mu.Lock()
+	index := slices.IndexFunc(s.accounts, func(account Account) bool { return account.ID == id })
+	if index < 0 {
+		s.mu.Unlock()
+		return fmt.Errorf("account %q not found", id)
+	}
+	account := s.accounts[index]
+	accountRoot := filepath.Clean(filepath.Join(s.root, "accounts", id))
+	if account.Controller || filepath.Clean(filepath.Dir(account.CodexHome)) != accountRoot {
+		s.mu.Unlock()
+		return fmt.Errorf("account %q is not a disposable imported account", id)
+	}
+	previousAccounts := slices.Clone(s.accounts)
+	previousOwners := maps.Clone(s.owners)
+	s.accounts = slices.Delete(s.accounts, index, index+1)
+	for threadID, owner := range s.owners {
+		if owner == id {
+			delete(s.owners, threadID)
+		}
+	}
+	if err := s.saveLocked(); err != nil {
+		s.accounts = previousAccounts
+		s.owners = previousOwners
+		s.mu.Unlock()
+		return err
+	}
+	s.mu.Unlock()
+	if err := os.RemoveAll(accountRoot); err != nil {
+		return fmt.Errorf("remove imported account resources: %w", err)
+	}
+	return nil
 }
 
 func ensureJSONEnd(decoder *json.Decoder) error {

--- a/internal/state/auth_test.go
+++ b/internal/state/auth_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,6 +50,18 @@ func TestValidateImportedAuthRejectsUnsafeOrIncompleteShapes(t *testing.T) {
 				t.Fatal("invalid auth.json unexpectedly passed validation")
 			}
 		})
+	}
+}
+
+func TestValidateImportedAuthRejectsNormalizedFileOverLimit(t *testing.T) {
+	template := `{"auth_mode":"chatgpt","OPENAI_API_KEY":null,"tokens":{"access_token":"%s","refresh_token":"refresh","account_id":"normalized-size"}}`
+	withoutPadding := fmt.Sprintf(template, "")
+	contents := fmt.Sprintf(template, strings.Repeat("a", MaxImportedAuthBytes-len(withoutPadding)))
+	if len(contents) != MaxImportedAuthBytes {
+		t.Fatalf("fixture size = %d, want %d", len(contents), MaxImportedAuthBytes)
+	}
+	if _, _, err := validateImportedAuth([]byte(contents)); err == nil || !strings.Contains(err.Error(), "normalized auth.json exceeds") {
+		t.Fatalf("normalized oversize error = %v", err)
 	}
 }
 

--- a/internal/state/auth_test.go
+++ b/internal/state/auth_test.go
@@ -1,0 +1,103 @@
+package state
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const validImportedAuth = `{
+  "auth_mode": "chatgpt",
+  "OPENAI_API_KEY": null,
+  "tokens": {
+    "id_token": "id-token-test",
+    "access_token": "access-token-test",
+    "refresh_token": "refresh-token-test",
+    "account_id": "account-test"
+  },
+  "last_refresh": "2026-08-24T00:00:00Z"
+}`
+
+func TestValidateImportedAuthAcceptsNativeRefreshableBundle(t *testing.T) {
+	normalized, accountID, err := validateImportedAuth([]byte(validImportedAuth))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if accountID != "account-test" {
+		t.Fatalf("account ID = %q", accountID)
+	}
+	if !strings.HasSuffix(string(normalized), "\n") || !strings.Contains(string(normalized), `"refresh_token": "refresh-token-test"`) {
+		t.Fatalf("unexpected normalized auth: %s", normalized)
+	}
+}
+
+func TestValidateImportedAuthRejectsUnsafeOrIncompleteShapes(t *testing.T) {
+	tests := map[string]string{
+		"api key":          strings.Replace(validImportedAuth, `"OPENAI_API_KEY": null`, `"OPENAI_API_KEY": "sk-test"`, 1),
+		"wrong mode":       strings.Replace(validImportedAuth, `"chatgpt"`, `"apikey"`, 1),
+		"no refresh":       strings.Replace(validImportedAuth, `"refresh_token": "refresh-token-test",`, ``, 1),
+		"unknown root":     strings.Replace(validImportedAuth, `"last_refresh":`, `"extra": true, "last_refresh":`, 1),
+		"unknown token":    strings.Replace(validImportedAuth, `"account_id":`, `"extra": true, "account_id":`, 1),
+		"bad refresh time": strings.Replace(validImportedAuth, `"2026-08-24T00:00:00Z"`, `"yesterday"`, 1),
+		"trailing JSON":    validImportedAuth + `{}`,
+	}
+	for name, contents := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := validateImportedAuth([]byte(contents)); err == nil {
+				t.Fatal("invalid auth.json unexpectedly passed validation")
+			}
+		})
+	}
+}
+
+func TestAddAccountWithAuthWritesPrivateFileAndRejectsDuplicate(t *testing.T) {
+	root := t.TempDir()
+	store, err := Open(filepath.Join(root, "mux"), filepath.Join(root, "primary"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	account, err := store.AddAccountWithAuth("Imported", []byte(validImportedAuth))
+	if err != nil {
+		t.Fatal(err)
+	}
+	authPath := filepath.Join(account.CodexHome, "auth.json")
+	info, err := os.Stat(authPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("auth.json mode = %#o, want 0600", mode)
+	}
+	if got := authAccountID(authPath); got != "account-test" {
+		t.Fatalf("stored account ID = %q", got)
+	}
+	if _, err := store.AddAccountWithAuth("Duplicate", []byte(validImportedAuth)); err == nil {
+		t.Fatal("duplicate ChatGPT account unexpectedly imported")
+	}
+	if accounts := store.Accounts(); len(accounts) != 2 {
+		t.Fatalf("account count = %d, want primary plus one imported", len(accounts))
+	}
+}
+
+func TestAddAccountWithAuthRejectsPrimaryAccountID(t *testing.T) {
+	root := t.TempDir()
+	primary := filepath.Join(root, "primary")
+	if err := os.MkdirAll(primary, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(primary, "auth.json"), []byte(validImportedAuth), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(filepath.Join(root, "mux"), primary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AddAccountWithAuth("Duplicate Primary", []byte(validImportedAuth)); !errors.Is(err, ErrDuplicateChatGPTAccount) {
+		t.Fatalf("duplicate primary error = %v, want ErrDuplicateChatGPTAccount", err)
+	}
+	if accounts := store.Accounts(); len(accounts) != 1 {
+		t.Fatalf("account count = %d after duplicate primary import, want 1", len(accounts))
+	}
+}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -158,7 +158,10 @@ func (s *Store) Controller() (Account, bool) {
 func (s *Store) AddAccount(label string) (Account, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.addAccountLocked(label, nil)
+}
 
+func (s *Store) addAccountLocked(label string, authContents []byte) (Account, error) {
 	label = strings.TrimSpace(label)
 	if label == "" {
 		label = fmt.Sprintf("Subscription %d", len(s.accounts)+1)
@@ -176,6 +179,11 @@ func (s *Store) AddAccount(label string) (Account, error) {
 	}
 	if err := syncIsolatedConfig(s.primaryCodexHome, codexHome); err != nil {
 		return Account{}, fmt.Errorf("write account config: %w", err)
+	}
+	if authContents != nil {
+		if err := atomicWritePrivate(filepath.Join(codexHome, "auth.json"), authContents); err != nil {
+			return Account{}, fmt.Errorf("write account credentials: %w", err)
+		}
 	}
 
 	account := Account{

--- a/ui/account-menu.js
+++ b/ui/account-menu.js
@@ -233,6 +233,7 @@ function CodexMuxAccountMenu() {
   const [busy, setBusy] = kXc.useState(false);
   const [error, setError] = kXc.useState("");
   const [login, setLogin] = kXc.useState(null);
+  const [addMethodOpen, setAddMethodOpen] = kXc.useState(false);
   const [codeCopied, setCodeCopied] = kXc.useState(false);
   const loginAccountId = login?.accountId || null;
 
@@ -284,15 +285,16 @@ function CodexMuxAccountMenu() {
   }, [refresh, loginAccountId]);
 
   kXc.useEffect(() => {
-    if (!login) return;
+    if (!login && !addMethodOpen) return;
     const allowEscapeDismissal = (event) => {
       if (event.key !== "Escape") return;
       codexMuxLoginActive = false;
       setLogin(null);
+      setAddMethodOpen(false);
     };
     window.addEventListener("keydown", allowEscapeDismissal, true);
     return () => window.removeEventListener("keydown", allowEscapeDismissal, true);
-  }, [login]);
+  }, [login, addMethodOpen]);
 
   const connected = accounts.filter(
     (account) => account.connected && account.enabled,
@@ -311,6 +313,8 @@ function CodexMuxAccountMenu() {
   async function addSubscription(event) {
     event.preventDefault();
     if (busy) return;
+    codexMuxLoginActive = true;
+    setAddMethodOpen(false);
     setBusy(true);
     setError("");
     try {
@@ -330,10 +334,84 @@ function CodexMuxAccountMenu() {
       setLogin(pendingLogin);
       await refresh();
     } catch (requestError) {
+      codexMuxLoginActive = false;
       setError(requestError.message);
     } finally {
       setBusy(false);
     }
+  }
+
+  function chooseAddMethod(event) {
+    event.preventDefault();
+    if (busy) return;
+    codexMuxLoginActive = true;
+    setAddMethodOpen(true);
+  }
+
+  function cancelAddMethod(event) {
+    event.preventDefault();
+    if (busy) return;
+    codexMuxLoginActive = false;
+    setAddMethodOpen(false);
+  }
+
+  function importSubscription(event) {
+    event.preventDefault();
+    if (busy) return;
+    codexMuxLoginActive = true;
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = "application/json,.json";
+    input.hidden = true;
+    document.body.append(input);
+    codexMuxLoginActive = true;
+    const cleanup = () => {
+      codexMuxLoginActive = false;
+      input.remove();
+    };
+    input.addEventListener("cancel", cleanup, { once: true });
+    input.addEventListener(
+      "change",
+      async () => {
+        const file = input.files?.[0];
+        if (!file) {
+          cleanup();
+          return;
+        }
+        setBusy(true);
+        setError("");
+        try {
+          if (file.size > 64 * 1024) {
+            throw new Error("auth.json must be smaller than 64 KB.");
+          }
+          const auth = JSON.parse(await file.text());
+          if (auth == null || Array.isArray(auth) || typeof auth !== "object") {
+            throw new Error("auth.json must contain one JSON object.");
+          }
+          await codexMuxRequest("/accounts/import", {
+            method: "POST",
+            body: JSON.stringify({
+              label: `Subscription ${accounts.length + 1}`,
+              auth,
+            }),
+          });
+          await refresh();
+        } catch (requestError) {
+          const message =
+            requestError instanceof SyntaxError
+              ? "auth.json is not valid JSON."
+              : requestError.message;
+          await refresh();
+          setError(message);
+        } finally {
+          setBusy(false);
+          setAddMethodOpen(false);
+          cleanup();
+        }
+      },
+      { once: true },
+    );
+    input.click();
   }
 
   async function copyCodeAndContinue(event) {
@@ -463,17 +541,54 @@ function CodexMuxAccountMenu() {
   }
 
   if (!loading) {
-    rows.push(
-      (0, e7.jsx)(
-        _H,
-        {
-          LeftIcon: CodexMuxPlusIcon,
-          onSelect: addSubscription,
-          children: busy ? "Adding subscription…" : "Add another subscription",
-        },
-        "codex-mux-add",
-      ),
-    );
+    if (addMethodOpen) {
+      rows.push(
+        (0, e7.jsx)(
+          _H,
+          {
+            LeftIcon: CodexMuxPlusIcon,
+            SubText: "Sign in with a one-time device code",
+            onSelect: addSubscription,
+            children: busy ? "Working…" : "Continue with ChatGPT",
+          },
+          "codex-mux-add-device-code",
+        ),
+      );
+      rows.push(
+        (0, e7.jsx)(
+          _H,
+          {
+            LeftIcon: CodexMuxCopyIcon,
+            SubText: "Use an existing Codex login file",
+            onSelect: importSubscription,
+            children: busy ? "Working…" : "Import auth.json",
+          },
+          "codex-mux-import-auth",
+        ),
+      );
+      rows.push(
+        (0, e7.jsx)(
+          _H,
+          {
+            onSelect: cancelAddMethod,
+            children: "Cancel",
+          },
+          "codex-mux-cancel-add",
+        ),
+      );
+    } else {
+      rows.push(
+        (0, e7.jsx)(
+          _H,
+          {
+            LeftIcon: CodexMuxPlusIcon,
+            onSelect: chooseAddMethod,
+            children: "Add another subscription",
+          },
+          "codex-mux-add",
+        ),
+      );
+    }
   }
   rows.push((0, e7.jsx)(CH.Separator, {}, "codex-mux-separator"));
   return (0, e7.jsx)(e7.Fragment, { children: rows });

--- a/ui/account-menu.js
+++ b/ui/account-menu.js
@@ -365,19 +365,40 @@ function CodexMuxAccountMenu() {
     input.hidden = true;
     document.body.append(input);
     codexMuxLoginActive = true;
+    let pickerFinished = false;
+    let cleanedUp = false;
     const cleanup = () => {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      window.removeEventListener("focus", detectPickerDismissal);
+      input.removeEventListener("cancel", cancelPicker);
       codexMuxLoginActive = false;
       input.remove();
     };
-    input.addEventListener("cancel", cleanup, { once: true });
+    const cancelPicker = () => {
+      if (pickerFinished) return;
+      pickerFinished = true;
+      setAddMethodOpen(false);
+      cleanup();
+    };
+    const detectPickerDismissal = () => {
+      window.setTimeout(() => {
+        if (!pickerFinished && !input.files?.length) cancelPicker();
+      }, 0);
+    };
+    input.addEventListener("cancel", cancelPicker, { once: true });
+    window.addEventListener("focus", detectPickerDismissal, { once: true });
     input.addEventListener(
       "change",
       async () => {
         const file = input.files?.[0];
         if (!file) {
-          cleanup();
+          cancelPicker();
           return;
         }
+        pickerFinished = true;
+        window.removeEventListener("focus", detectPickerDismissal);
+        input.removeEventListener("cancel", cancelPicker);
         setBusy(true);
         setError("");
         try {


### PR DESCRIPTION
## Summary

- Add an `Add another subscription` choice between the existing ChatGPT device-code flow and `Import auth.json`.
- Accept the current native ChatGPT auth shape, write it to the new isolated `CODEX_HOME` before its app-server starts, and verify the result with `account/read`.
- Reject malformed, oversized, API-key, unknown-field, and duplicate-account imports without returning token material.
- Roll back failed imports completely: remove the child from the pool, stop it, remove persisted account state, and wipe the generated account directory.

## Why

The Router currently requires a new device-code login for every secondary account, even when the user already has a complete Codex ChatGPT login file.

CC Switch independently uses the same native bundle shape and records why the live file must remain under Codex ownership: the CLI rotates refresh tokens, so `account_id` is stable while access-token fingerprints are not. See its current [shape validation and bundle builder](https://github.com/farion1231/cc-switch/blob/5ca9459d50ea4beea6a81bbc509de6ec5b6b09ca/src-tauri/src/codex_config.rs#L376-L460) and [refresh-token adoption notes](https://github.com/farion1231/cc-switch/blob/5ca9459d50ea4beea6a81bbc509de6ec5b6b09ca/src-tauri/src/codex_config.rs#L609-L680).

This PR does not implement OAuth refresh. Each official Codex child continues to refresh and rewrite its own isolated `auth.json`.

## Security behavior

- Enforce the 64 KiB limit on both the selected file and the normalized JSON that is stored.
- Require `auth_mode = chatgpt`, a null or absent `OPENAI_API_KEY`, and non-empty access token, refresh token, and account ID.
- Block an account ID already used by Primary or another secondary account.
- Write through a new mode-`0600` temporary file, flush it, then rename it atomically.
- On startup, initialization, or `account/read` verification failure, stop any started child with bounded graceful shutdown plus forced-kill fallback, remove the account from persisted routing state, and delete its generated resource directory including token material.
- Keep the import on the existing token-authenticated `127.0.0.1` control API. Tokens are not logged or included in responses or Router state.
- Clean up the hidden file input and login-active UI state on the native `cancel` event or the window-focus dismissal fallback when Chromium emits no `change` event.

## Verification

- `npm run check`
- `xcrun clang -fsyntax-only -Wall -Wextra native/launcher.c`
- `npm run release:check`
- `go test -race ./internal/state ./internal/mux`
- Focused tests cover accepted/rejected auth shapes, `0600` permissions, Primary and secondary duplicate IDs, normalized JSON expanding past 64 KiB, authenticated first child start, process-start failure, post-start initialization failure, and disconnected verification rollback. The rollback assertions reopen persisted state and require no child or generated account resources to remain.
- Live countercheck with ChatGPT `26.818.41509` and app-server `0.149.0-alpha.4.1`: importing Primary's own file returned HTTP 409 and kept the configured account count at `1 -> 1`.

## Scope and limitation

This change does not touch the installer, signing path, ASAR compatibility table, routing policy, or existing device-code flow. PR #21 is an independent subscription-removal lifecycle and is not a dependency of this import fix; both branches touch `internal/state/store.go` and `ui/account-menu.js`, so merge order may require a normal conflict resolution without changing either PR's scope.

I did not build a patched app against the recorded `26.803.61601` bundle because this Mac has `26.818.41509`. The injected menu change passed `node --check`; the endpoint and real app-server path were exercised live through an isolated profile.
