### PR TITLE
Add subscription removal with recoverable account backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ this project uses [Semantic Versioning](https://semver.org/).
   rebuilds, recoverable upgrades, and automatic launch.
 - Reset-aware routing that prioritizes weekly quota at risk of expiring and
   gives a bounded boost to subscriptions with banked usage resets.
+- Subscription removal from the native account menu: manage mode selects a
+  subscription, a second confirmation step spells out the consequences, and the
+  isolated account data is moved into a timestamped local backup.
 
 ## [0.1.0] - 2026-08-15
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,17 @@ The profile menu displays combined weekly usage followed by one row per
 subscription. Email addresses remain masked until hovered. The final row always
 starts another sign-in.
 
+### Remove a subscription
+
+1. Open the profile menu and select **Manage subscriptions**.
+2. Select the subscription to remove; the Primary subscription cannot be
+   removed.
+3. Confirm the removal. The subscription's chats leave this app immediately,
+   routing stops, and its isolated account data is moved to
+   `~/.codex-mux/backups/accounts/<id>-<timestamp>`. Delete backups manually
+   once you are sure you will not need them; they contain the account's
+   credentials and conversation history.
+
 ## Routing behavior
 
 | Situation | Behaviour |
@@ -241,7 +252,7 @@ helper and socket paths and are not relocatable or intended for redistribution.
 | `~/.codex` | Primary credentials, conversations, and cache |
 | `~/.codex-mux/state.json` | Account metadata and sticky thread ownership |
 | `~/.codex-mux/accounts/<id>/codex-home` | Isolated secondary account data |
-| `~/.codex-mux/control-token` | Token for the loopback-only control service |
+| `~/.codex-mux/backups/accounts/<id>-<timestamp>` | Account data preserved when a subscription is removed |
 | `~/.codex-mux/backups` | Recoverable app and helper backups |
 | `~/Library/Application Support/Codex Subscription Router` | Independent desktop profile |
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ helper and socket paths and are not relocatable or intended for redistribution.
 | `~/.codex` | Primary credentials, conversations, and cache |
 | `~/.codex-mux/state.json` | Account metadata and sticky thread ownership |
 | `~/.codex-mux/accounts/<id>/codex-home` | Isolated secondary account data |
+| `~/.codex-mux/control-token` | Token for the loopback-only control service |
 | `~/.codex-mux/backups/accounts/<id>-<timestamp>` | Account data preserved when a subscription is removed |
 | `~/.codex-mux/backups` | Recoverable app and helper backups |
 | `~/Library/Application Support/Codex Subscription Router` | Independent desktop profile |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,5 +59,5 @@ before forwarding the strict RPC request to the chosen child.
 The renderer talks to a loopback-only HTTP service on port 48123. All private
 routes require a random 256-bit token. CORS is limited to the copied app's
 `app://-` origin. The service exposes account metadata, aggregated usage and
-profile data, thread ownership, login/logout actions, and an authenticated SSE
-event stream; it never returns OAuth tokens.
+profile data, thread ownership, login/logout and subscription-removal actions,
+and an authenticated SSE event stream; it never returns OAuth tokens.

--- a/internal/backend/child.go
+++ b/internal/backend/child.go
@@ -143,6 +143,20 @@ func (c *Child) Close() error {
 	return c.command.Process.Signal(os.Interrupt)
 }
 
+// CloseAndWait stops the app-server and waits until its process has exited so
+// callers can safely move or replace its CODEX_HOME.
+func (c *Child) CloseAndWait(ctx context.Context) error {
+	if err := c.Close(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return err
+	}
+	select {
+	case <-c.closed:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func (c *Child) readLoop(stdout io.Reader) {
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 64*1024), 64*1024*1024)

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -217,6 +217,14 @@ func (s *Server) accountAction(response http.ResponseWriter, request *http.Reque
 		writeJSON(response, http.StatusOK, map[string]any{"account": account})
 		return
 	}
+	if len(parts) == 1 && request.Method == http.MethodDelete {
+		if err := s.mux.RemoveAccount(ctx, accountID); err != nil {
+			writeJSON(response, http.StatusBadRequest, map[string]any{"error": err.Error()})
+			return
+		}
+		writeJSON(response, http.StatusOK, map[string]any{"ok": true})
+		return
+	}
 	if len(parts) == 2 && parts[1] == "rate-limit-resets" && request.Method == http.MethodGet {
 		result, err := s.mux.RateLimitResetCredits(ctx, accountID)
 		if err != nil {
@@ -327,8 +335,7 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 			response.Header().Set("Access-Control-Allow-Origin", "app://-")
 			response.Header().Set("Vary", "Origin")
 		}
-		response.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-Codex-Mux-Token")
-		response.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, OPTIONS")
+		response.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
 		response.Header().Set("Cache-Control", "no-store")
 		response.Header().Set("Referrer-Policy", "no-referrer")
 		response.Header().Set("X-Content-Type-Options", "nosniff")

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -335,6 +335,7 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 			response.Header().Set("Access-Control-Allow-Origin", "app://-")
 			response.Header().Set("Vary", "Origin")
 		}
+		response.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-Codex-Mux-Token")
 		response.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
 		response.Header().Set("Cache-Control", "no-store")
 		response.Header().Set("Referrer-Policy", "no-referrer")

--- a/internal/control/server_test.go
+++ b/internal/control/server_test.go
@@ -1,0 +1,121 @@
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/b-nnett/codex-subscription-router/internal/mux"
+	"github.com/b-nnett/codex-subscription-router/internal/state"
+)
+
+func newRemoveTestServer(t *testing.T) (url string, token string, accountID string) {
+	t.Helper()
+	root := t.TempDir()
+	store, err := state.Open(filepath.Join(root, "mux"), filepath.Join(root, "primary"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	added, err := store.AddAccount("Work")
+	if err != nil {
+		t.Fatal(err)
+	}
+	multiplexer, err := mux.New(mux.Options{
+		RealExecutable: "/usr/bin/true",
+		Store:          store,
+		Output:         io.Discard,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	token = "test-token-0123456789abcdef"
+	server := New(listener.Addr().String(), token, multiplexer, false)
+	go func() { _ = server.Serve(listener) }()
+	shutdownContext, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(func() { _ = server.Shutdown(shutdownContext); cancel() })
+	return "http://" + listener.Addr().String(), token, added.ID
+}
+
+func TestDeleteAccountRemovesSecondarySubscription(t *testing.T) {
+	url, token, accountID := newRemoveTestServer(t)
+
+	deleteRequest, err := http.NewRequest(http.MethodDelete, url+"/v1/accounts/"+accountID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deleteRequest.Header.Set("X-Codex-Mux-Token", token)
+	response, err := http.DefaultClient.Do(deleteRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("delete returned %d, want 200", response.StatusCode)
+	}
+
+	accountsRequest, err := http.NewRequest(http.MethodGet, url+"/v1/accounts", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accountsRequest.Header.Set("X-Codex-Mux-Token", token)
+	listResponse, err := http.DefaultClient.Do(accountsRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listResponse.Body.Close()
+	body, _ := io.ReadAll(listResponse.Body)
+	var listed struct {
+		Accounts []struct {
+			ID string `json:"id"`
+		} `json:"accounts"`
+	}
+	if err := json.Unmarshal(body, &listed); err != nil {
+		t.Fatalf("decode accounts response: %v", err)
+	}
+	for _, account := range listed.Accounts {
+		if account.ID == accountID {
+			t.Fatalf("removed account still listed: %s", body)
+		}
+	}
+}
+
+func TestDeleteAccountRejectsPrimaryAndBadToken(t *testing.T) {
+	url, token, _ := newRemoveTestServer(t)
+
+	primaryRequest, err := http.NewRequest(http.MethodDelete, url+"/v1/accounts/primary", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	primaryRequest.Header.Set("X-Codex-Mux-Token", token)
+	response, err := http.DefaultClient.Do(primaryRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusBadRequest {
+		t.Fatalf("primary delete returned %d, want 400", response.StatusCode)
+	}
+
+	unauthorized, err := http.NewRequest(http.MethodDelete, url+"/v1/accounts/primary", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unauthorized.Header.Set("X-Codex-Mux-Token", "wrong-token-0123456789")
+	denied, err := http.DefaultClient.Do(unauthorized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer denied.Body.Close()
+	if denied.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated delete returned %d, want 401", denied.StatusCode)
+	}
+}

--- a/internal/control/server_test.go
+++ b/internal/control/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -40,9 +41,40 @@ func newRemoveTestServer(t *testing.T) (url string, token string, accountID stri
 	token = "test-token-0123456789abcdef"
 	server := New(listener.Addr().String(), token, multiplexer, false)
 	go func() { _ = server.Serve(listener) }()
-	shutdownContext, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	t.Cleanup(func() { _ = server.Shutdown(shutdownContext); cancel() })
+	t.Cleanup(func() {
+		shutdownContext, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownContext)
+	})
 	return "http://" + listener.Addr().String(), token, added.ID
+}
+
+func TestSecurityHeadersAllowAuthenticatedDeletePreflight(t *testing.T) {
+	url, _, _ := newRemoveTestServer(t)
+	request, err := http.NewRequest(http.MethodOptions, url+"/v1/accounts/subscription", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Origin", "app://-")
+	request.Header.Set("Access-Control-Request-Method", http.MethodDelete)
+	request.Header.Set("Access-Control-Request-Headers", "content-type,x-codex-mux-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("preflight returned %d, want 204", response.StatusCode)
+	}
+	if got := response.Header.Get("Access-Control-Allow-Origin"); got != "app://-" {
+		t.Fatalf("allowed origin = %q, want app://-", got)
+	}
+	if got := response.Header.Get("Access-Control-Allow-Headers"); got != "Content-Type, X-Codex-Mux-Token" {
+		t.Fatalf("allowed headers = %q", got)
+	}
+	if got := response.Header.Get("Access-Control-Allow-Methods"); !strings.Contains(got, http.MethodDelete) {
+		t.Fatalf("allowed methods = %q, want DELETE", got)
+	}
 }
 
 func TestDeleteAccountRemovesSecondarySubscription(t *testing.T) {

--- a/internal/mux/accounts.go
+++ b/internal/mux/accounts.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"sort"
 	"time"
 
@@ -114,6 +116,57 @@ func (m *Multiplexer) UpdateAccount(ctx context.Context, id string, label *strin
 		return AccountSnapshot{}, err
 	}
 	return m.accountSnapshot(ctx, id)
+}
+
+// RemoveAccount deletes a subscription from the routing pool: its app-server
+// child is stopped, thread ownership is cleared, and the isolated Codex home
+// is moved into a timestamped backup so the removal stays recoverable. The
+// Primary subscription cannot be removed. Order matters: every step before
+// the state commit is reversible, and the commit is what makes it permanent.
+func (m *Multiplexer) RemoveAccount(ctx context.Context, id string) error {
+	account, ok := m.store.Account(id)
+	if !ok {
+		return fmt.Errorf("account %q not found", id)
+	}
+	if account.Controller {
+		return errors.New("the Primary subscription cannot be removed")
+	}
+	if child, ok := m.child(id); ok {
+		_ = child.Close()
+		m.childrenMu.Lock()
+		delete(m.children, id)
+		m.childrenMu.Unlock()
+	}
+	if err := backupAccountHome(m.store.Root(), account); err != nil {
+		return fmt.Errorf("back up subscription home: %w", err)
+	}
+	if _, err := m.store.RemoveAccount(id); err != nil {
+		return err
+	}
+	m.publish(Event{Type: "account-removed", AccountID: id, Message: account.Label})
+	return nil
+}
+
+// backupAccountHome moves accounts/<id> (the isolated Codex home and any
+// sibling state) under backups/accounts/<id>-<unix-seconds>. Missing
+// directories are ignored: nothing was created, so nothing is lost.
+func backupAccountHome(root string, account state.Account) error {
+	source := filepath.Dir(account.CodexHome)
+	if _, err := os.Stat(source); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	backupRoot := filepath.Join(root, "backups", "accounts")
+	if err := os.MkdirAll(backupRoot, 0o700); err != nil {
+		return fmt.Errorf("create account backup root: %w", err)
+	}
+	destination := filepath.Join(backupRoot, fmt.Sprintf("%s-%d", account.ID, time.Now().Unix()))
+	if err := os.Rename(source, destination); err != nil {
+		return fmt.Errorf("move account home: %w", err)
+	}
+	return nil
 }
 
 func (m *Multiplexer) ThreadAccount(ctx context.Context, threadID string) (AccountSnapshot, error) {

--- a/internal/mux/accounts.go
+++ b/internal/mux/accounts.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/b-nnett/codex-subscription-router/internal/backend"
 	"github.com/b-nnett/codex-subscription-router/internal/state"
 )
 
@@ -124,6 +125,11 @@ func (m *Multiplexer) UpdateAccount(ctx context.Context, id string, label *strin
 // Primary subscription cannot be removed. Order matters: every step before
 // the state commit is reversible, and the commit is what makes it permanent.
 func (m *Multiplexer) RemoveAccount(ctx context.Context, id string) error {
+	m.removalMu.Lock()
+	defer m.removalMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	account, ok := m.store.Account(id)
 	if !ok {
 		return fmt.Errorf("account %q not found", id)
@@ -131,42 +137,84 @@ func (m *Multiplexer) RemoveAccount(ctx context.Context, id string) error {
 	if account.Controller {
 		return errors.New("the Primary subscription cannot be removed")
 	}
-	if child, ok := m.child(id); ok {
-		_ = child.Close()
-		m.childrenMu.Lock()
-		delete(m.children, id)
-		m.childrenMu.Unlock()
+	child, hadChild := m.takeChild(id)
+	if hadChild {
+		shutdownContext, cancel := context.WithTimeout(context.Background(), requestTimeout)
+		closeErr := child.CloseAndWait(shutdownContext)
+		cancel()
+		if closeErr != nil {
+			restartErr := m.restartAccountChild(account)
+			return errors.Join(
+				fmt.Errorf("stop subscription app-server: %w", closeErr),
+				restartErr,
+			)
+		}
 	}
-	if err := backupAccountHome(m.store.Root(), account); err != nil {
-		return fmt.Errorf("back up subscription home: %w", err)
+	now := time.Now
+	if m.now != nil {
+		now = m.now
 	}
-	if _, err := m.store.RemoveAccount(id); err != nil {
+	if _, err := m.store.RemoveAccountWithStage(id, func(account state.Account) (func() error, error) {
+		rollback, err := stageAccountHomeBackup(m.store.Root(), account, now())
+		if err != nil {
+			return nil, fmt.Errorf("back up subscription home: %w", err)
+		}
+		return rollback, nil
+	}); err != nil {
+		if hadChild {
+			return errors.Join(err, m.restartAccountChild(account))
+		}
 		return err
 	}
 	m.publish(Event{Type: "account-removed", AccountID: id, Message: account.Label})
 	return nil
 }
 
-// backupAccountHome moves accounts/<id> (the isolated Codex home and any
-// sibling state) under backups/accounts/<id>-<unix-seconds>. Missing
-// directories are ignored: nothing was created, so nothing is lost.
-func backupAccountHome(root string, account state.Account) error {
+func (m *Multiplexer) takeChild(accountID string) (*backend.Child, bool) {
+	m.childrenMu.Lock()
+	defer m.childrenMu.Unlock()
+	child, ok := m.children[accountID]
+	if ok {
+		delete(m.children, accountID)
+	}
+	return child, ok
+}
+
+func (m *Multiplexer) restartAccountChild(account state.Account) error {
+	restartContext, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+	if _, err := m.startChild(restartContext, account); err != nil {
+		return fmt.Errorf("restore subscription app-server: %w", err)
+	}
+	return nil
+}
+
+// stageAccountHomeBackup moves accounts/<id> (the isolated Codex home and any
+// sibling state) under backups/accounts/<id>-<unix-seconds> and returns a
+// rollback that restores the original location. Missing directories are
+// ignored: nothing was created, so nothing is lost.
+func stageAccountHomeBackup(root string, account state.Account, now time.Time) (func() error, error) {
 	source := filepath.Dir(account.CodexHome)
 	if _, err := os.Stat(source); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil
+			return nil, nil
 		}
-		return err
+		return nil, err
 	}
 	backupRoot := filepath.Join(root, "backups", "accounts")
 	if err := os.MkdirAll(backupRoot, 0o700); err != nil {
-		return fmt.Errorf("create account backup root: %w", err)
+		return nil, fmt.Errorf("create account backup root: %w", err)
 	}
-	destination := filepath.Join(backupRoot, fmt.Sprintf("%s-%d", account.ID, time.Now().Unix()))
+	destination := filepath.Join(backupRoot, fmt.Sprintf("%s-%d", account.ID, now.Unix()))
 	if err := os.Rename(source, destination); err != nil {
-		return fmt.Errorf("move account home: %w", err)
+		return nil, fmt.Errorf("move account home: %w", err)
 	}
-	return nil
+	return func() error {
+		if err := os.Rename(destination, source); err != nil {
+			return fmt.Errorf("restore account home: %w", err)
+		}
+		return nil
+	}, nil
 }
 
 func (m *Multiplexer) ThreadAccount(ctx context.Context, threadID string) (AccountSnapshot, error) {

--- a/internal/mux/accounts_test.go
+++ b/internal/mux/accounts_test.go
@@ -208,3 +208,130 @@ func TestRemoveAccountBacksUpHomeAndPublishesEvent(t *testing.T) {
 		t.Fatal("no account-removed event was published")
 	}
 }
+
+func TestTakeChildRemovesMapEntryBeforeShutdown(t *testing.T) {
+	child := &backend.Child{}
+	multiplexer := &Multiplexer{children: map[string]*backend.Child{"work": child}}
+	taken, ok := multiplexer.takeChild("work")
+	if !ok || taken != child {
+		t.Fatalf("unexpected detached child: child=%p ok=%v", taken, ok)
+	}
+	if _, ok := multiplexer.child("work"); ok {
+		t.Fatal("child remained discoverable after it was detached")
+	}
+}
+
+func TestRemoveAccountRestartsChildWhenBackupFails(t *testing.T) {
+	store, account, multiplexer := newRunningRemovalMultiplexer(t)
+	original, ok := multiplexer.child(account.ID)
+	if !ok {
+		t.Fatal("account child did not start")
+	}
+	if err := os.WriteFile(filepath.Join(store.Root(), "backups"), []byte("blocked"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := multiplexer.RemoveAccount(context.Background(), account.ID); err == nil {
+		t.Fatal("removal unexpectedly succeeded with an invalid backup root")
+	}
+	if _, ok := store.Account(account.ID); !ok {
+		t.Fatal("account state changed after backup failure")
+	}
+	restarted, ok := multiplexer.child(account.ID)
+	if !ok || restarted == original {
+		t.Fatalf("account child was not restarted: child=%p original=%p", restarted, original)
+	}
+	if _, err := os.Stat(account.CodexHome); err != nil {
+		t.Fatalf("account home changed after backup failure: %v", err)
+	}
+}
+
+func TestRemoveAccountRestoresHomeStateAndChildWhenStateCommitFails(t *testing.T) {
+	store, account, multiplexer := newRunningRemovalMultiplexer(t)
+	original, _ := multiplexer.child(account.ID)
+	if err := os.Mkdir(filepath.Join(store.Root(), "state.json.tmp"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := multiplexer.RemoveAccount(context.Background(), account.ID); err == nil {
+		t.Fatal("removal unexpectedly succeeded with an unwritable state temporary path")
+	}
+	if _, ok := store.Account(account.ID); !ok {
+		t.Fatal("account state was not rolled back")
+	}
+	if _, err := os.Stat(filepath.Join(account.CodexHome, "config.toml")); err != nil {
+		t.Fatalf("account home was not restored: %v", err)
+	}
+	backups, err := filepath.Glob(filepath.Join(store.Root(), "backups", "accounts", account.ID+"-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(backups) != 0 {
+		t.Fatalf("rollback left account backups behind: %v", backups)
+	}
+	restarted, ok := multiplexer.child(account.ID)
+	if !ok || restarted == original {
+		t.Fatalf("account child was not restored: child=%p original=%p", restarted, original)
+	}
+}
+
+func TestConcurrentRemoveAccountCommitsOnceWithoutRestartingRemovedChild(t *testing.T) {
+	store, account, multiplexer := newRunningRemovalMultiplexer(t)
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			<-start
+			results <- multiplexer.RemoveAccount(context.Background(), account.ID)
+		}()
+	}
+	close(start)
+	first := <-results
+	second := <-results
+	if (first == nil) == (second == nil) {
+		t.Fatalf("concurrent removals should produce one success: first=%v second=%v", first, second)
+	}
+	if _, ok := store.Account(account.ID); ok {
+		t.Fatal("removed account remained in state")
+	}
+	if _, ok := multiplexer.child(account.ID); ok {
+		t.Fatal("a concurrent removal restarted the removed account child")
+	}
+	backups, err := filepath.Glob(filepath.Join(store.Root(), "backups", "accounts", account.ID+"-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("concurrent removal created %d backups, want 1", len(backups))
+	}
+}
+
+func newRunningRemovalMultiplexer(t *testing.T) (*state.Store, state.Account, *Multiplexer) {
+	t.Helper()
+	root := t.TempDir()
+	store, err := state.Open(filepath.Join(root, "mux"), filepath.Join(root, "primary"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	account, err := store.AddAccount("Work")
+	if err != nil {
+		t.Fatal(err)
+	}
+	multiplexer, err := New(Options{
+		RealExecutable: "/bin/cat",
+		Store:          store,
+		Output:         os.Stderr,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := multiplexer.startChild(context.Background(), account); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		for _, entry := range multiplexer.childEntries() {
+			shutdownContext, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_ = entry.child.CloseAndWait(shutdownContext)
+			cancel()
+		}
+	})
+	return store, account, multiplexer
+}

--- a/internal/mux/accounts_test.go
+++ b/internal/mux/accounts_test.go
@@ -1,8 +1,15 @@
 package mux
 
 import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/b-nnett/codex-subscription-router/internal/backend"
+	"github.com/b-nnett/codex-subscription-router/internal/state"
 )
 
 func TestPlanLabel(t *testing.T) {
@@ -143,10 +150,61 @@ func TestRouteUrgencyFallsBackToWeeklyUtilization(t *testing.T) {
 	lessUsed := routeUrgencyScore(now, &RateLimitWindow{
 		UsedPercent: 20, WindowDurationMins: &weeklyMinutes,
 	}, resetCreditMetadata{})
+
 	moreUsed := routeUrgencyScore(now, &RateLimitWindow{
 		UsedPercent: 80, WindowDurationMins: &weeklyMinutes,
 	}, resetCreditMetadata{})
 	if lessUsed <= moreUsed {
 		t.Fatalf("fallback should prefer the less-used account: less=%f more=%f", lessUsed, moreUsed)
+	}
+}
+
+func TestRemoveAccountBacksUpHomeAndPublishesEvent(t *testing.T) {
+	root := t.TempDir()
+	store, err := state.Open(filepath.Join(root, "mux"), filepath.Join(root, "primary"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	added, err := store.AddAccount("Work")
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := make(chan Event, 4)
+	multiplexer := &Multiplexer{
+		store:    store,
+		children: make(map[string]*backend.Child),
+		events:   map[chan Event]struct{}{events: {}},
+		now:      time.Now,
+	}
+
+	if err := multiplexer.RemoveAccount(context.Background(), "primary"); err == nil {
+		t.Fatal("removing the Primary subscription must fail")
+	}
+	if err := multiplexer.RemoveAccount(context.Background(), added.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := store.Account(added.ID); ok {
+		t.Fatal("removed account is still routable")
+	}
+	if _, err := os.Stat(added.CodexHome); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("isolated home was not moved out: %v", err)
+	}
+	backups, err := filepath.Glob(filepath.Join(store.Root(), "backups", "accounts", added.ID+"-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("expected exactly one account backup, found %d", len(backups))
+	}
+	if _, err := os.Stat(filepath.Join(backups[0], "codex-home", "config.toml")); err != nil {
+		t.Fatalf("backup is missing the isolated config: %v", err)
+	}
+	select {
+	case event := <-events:
+		if event.Type != "account-removed" || event.AccountID != added.ID {
+			t.Fatalf("unexpected removal event: %#v", event)
+		}
+	default:
+		t.Fatal("no account-removed event was published")
 	}
 }

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -60,6 +60,7 @@ type Multiplexer struct {
 	childrenMu sync.RWMutex
 	children   map[string]*backend.Child
 	inbound    chan backend.Inbound
+	removalMu  sync.Mutex
 
 	initializationMu sync.RWMutex
 	initializeParams json.RawMessage

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -35,6 +36,7 @@ type persistedState struct {
 // databases remain inside each account's isolated Codex home.
 type Store struct {
 	mu               sync.RWMutex
+	lifecycleMu      sync.Mutex
 	root             string
 	path             string
 	primaryCodexHome string
@@ -108,6 +110,8 @@ func (s *Store) Root() string {
 // isolated subscription. Credential stores and project trust remain local to
 // each account; syncIsolatedConfig deliberately excludes both.
 func (s *Store) SyncManagedConfig() error {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
 	s.mu.RLock()
 	accounts := slices.Clone(s.accounts)
 	primaryCodexHome := s.primaryCodexHome
@@ -221,6 +225,20 @@ func (s *Store) UpdateAccount(id string, label *string, enabled *bool) (Account,
 // drops every thread assignment it owned. The isolated Codex home is not
 // deleted here; the caller decides its fate so a removal can stay recoverable.
 func (s *Store) RemoveAccount(id string) (Account, error) {
+	return s.RemoveAccountWithStage(id, nil)
+}
+
+// RemoveAccountWithStage serializes an external reversible stage with config
+// synchronization and the routing-state commit. The stage normally moves the
+// isolated home to a backup and returns a rollback that restores it. If state
+// persistence fails, both the in-memory state and the staged filesystem change
+// are restored before the store lock is released.
+func (s *Store) RemoveAccountWithStage(
+	id string,
+	stage func(Account) (rollback func() error, err error),
+) (Account, error) {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for index := range s.accounts {
@@ -231,13 +249,32 @@ func (s *Store) RemoveAccount(id string) (Account, error) {
 			return Account{}, errors.New("the Primary subscription cannot be removed")
 		}
 		removed := s.accounts[index]
-		s.accounts = slices.Delete(s.accounts, index, index+1)
+		var rollback func() error
+		if stage != nil {
+			var err error
+			rollback, err = stage(removed)
+			if err != nil {
+				return Account{}, err
+			}
+		}
+
+		previousAccounts := s.accounts
+		previousOwners := s.owners
+		s.accounts = slices.Delete(slices.Clone(s.accounts), index, index+1)
+		s.owners = maps.Clone(s.owners)
 		for threadID, owner := range s.owners {
 			if owner == id {
 				delete(s.owners, threadID)
 			}
 		}
 		if err := s.saveLocked(); err != nil {
+			s.accounts = previousAccounts
+			s.owners = previousOwners
+			if rollback != nil {
+				if rollbackErr := rollback(); rollbackErr != nil {
+					return Account{}, errors.Join(err, fmt.Errorf("roll back account removal: %w", rollbackErr))
+				}
+			}
 			return Account{}, err
 		}
 		return removed, nil

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -217,6 +217,34 @@ func (s *Store) UpdateAccount(id string, label *string, enabled *bool) (Account,
 	return Account{}, fmt.Errorf("account %q not found", id)
 }
 
+// RemoveAccount deletes a non-controller account from routing state and
+// drops every thread assignment it owned. The isolated Codex home is not
+// deleted here; the caller decides its fate so a removal can stay recoverable.
+func (s *Store) RemoveAccount(id string) (Account, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for index := range s.accounts {
+		if s.accounts[index].ID != id {
+			continue
+		}
+		if s.accounts[index].Controller || samePath(s.accounts[index].CodexHome, s.primaryCodexHome) {
+			return Account{}, errors.New("the Primary subscription cannot be removed")
+		}
+		removed := s.accounts[index]
+		s.accounts = slices.Delete(s.accounts, index, index+1)
+		for threadID, owner := range s.owners {
+			if owner == id {
+				delete(s.owners, threadID)
+			}
+		}
+		if err := s.saveLocked(); err != nil {
+			return Account{}, err
+		}
+		return removed, nil
+	}
+	return Account{}, fmt.Errorf("account %q not found", id)
+}
+
 func (s *Store) ThreadOwner(threadID string) (string, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -172,3 +172,56 @@ func TestUpdateAccountPreservesController(t *testing.T) {
 		t.Fatalf("unexpected updated account: %#v", account)
 	}
 }
+
+func TestRemoveAccountClearsOwnershipAndPersists(t *testing.T) {
+	root := t.TempDir()
+	primaryHome := filepath.Join(root, "primary")
+	store, err := Open(filepath.Join(root, "mux"), primaryHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	added, err := store.AddAccount("Work")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetThreadOwner("thread-owned", added.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetThreadOwner("thread-primary", "primary"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.RemoveAccount("primary"); err == nil {
+		t.Fatal("removing the controller account must fail")
+	}
+
+	removed, err := store.RemoveAccount(added.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed.ID != added.ID {
+		t.Fatalf("unexpected removed account: %#v", removed)
+	}
+	if _, err := store.RemoveAccount(added.ID); err == nil {
+		t.Fatal("removing an already removed account must fail")
+	}
+	for _, account := range store.Accounts() {
+		if account.ID == added.ID {
+			t.Fatal("removed account is still present in state")
+		}
+	}
+	if owner, ok := store.ThreadOwner("thread-owned"); ok {
+		t.Fatalf("thread owned by the removed account kept its owner %q", owner)
+	}
+	if owner, ok := store.ThreadOwner("thread-primary"); !ok || owner != "primary" {
+		t.Fatalf("unrelated thread ownership was disturbed: owner=%q ok=%v", owner, ok)
+	}
+
+	reopened, err := Open(filepath.Join(root, "mux"), primaryHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := reopened.Account(added.ID); ok {
+		t.Fatal("removed account reappeared after reopening the store")
+	}
+}

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestStoreBootstrapsPrimaryAndPersistsThreadAffinity(t *testing.T) {
@@ -223,5 +224,117 @@ func TestRemoveAccountClearsOwnershipAndPersists(t *testing.T) {
 	}
 	if _, ok := reopened.Account(added.ID); ok {
 		t.Fatal("removed account reappeared after reopening the store")
+	}
+}
+
+func TestRemoveAccountRollsBackMemoryAndStageWhenPersistenceFails(t *testing.T) {
+	root := t.TempDir()
+	muxRoot := filepath.Join(root, "mux")
+	store, err := Open(muxRoot, filepath.Join(root, "primary"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	account, err := store.AddAccount("Work")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetThreadOwner("thread-work", account.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(muxRoot, "state.json.tmp"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	staged := false
+	rolledBack := false
+	_, err = store.RemoveAccountWithStage(account.ID, func(Account) (func() error, error) {
+		staged = true
+		return func() error {
+			rolledBack = true
+			return nil
+		}, nil
+	})
+	if err == nil {
+		t.Fatal("removal unexpectedly succeeded with an unwritable state temporary path")
+	}
+	if !staged || !rolledBack {
+		t.Fatalf("stage lifecycle = staged:%v rolledBack:%v", staged, rolledBack)
+	}
+	if _, ok := store.Account(account.ID); !ok {
+		t.Fatal("account was not restored in memory")
+	}
+	if owner, ok := store.ThreadOwner("thread-work"); !ok || owner != account.ID {
+		t.Fatalf("thread owner was not restored: owner=%q ok=%v", owner, ok)
+	}
+	reopened, err := Open(muxRoot, filepath.Join(root, "primary"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := reopened.Account(account.ID); !ok {
+		t.Fatal("persisted account was changed despite the failed commit")
+	}
+}
+
+func TestRemovalSerializesConfigSyncAndPreventsHomeRecreation(t *testing.T) {
+	root := t.TempDir()
+	primaryHome := filepath.Join(root, "primary")
+	if err := os.MkdirAll(primaryHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(primaryHome, "config.toml"), []byte("model = \"shared\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(filepath.Join(root, "mux"), primaryHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	account, err := store.AddAccount("Work")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Dir(account.CodexHome)
+	destination := filepath.Join(store.Root(), "backups", "staged")
+	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	stageStarted := make(chan struct{})
+	releaseStage := make(chan struct{})
+	removeDone := make(chan error, 1)
+	go func() {
+		_, removeErr := store.RemoveAccountWithStage(account.ID, func(Account) (func() error, error) {
+			if err := os.Rename(source, destination); err != nil {
+				return nil, err
+			}
+			close(stageStarted)
+			<-releaseStage
+			return func() error { return os.Rename(destination, source) }, nil
+		})
+		removeDone <- removeErr
+	}()
+	<-stageStarted
+
+	syncStarted := make(chan struct{})
+	syncDone := make(chan error, 1)
+	go func() {
+		close(syncStarted)
+		syncDone <- store.SyncManagedConfig()
+	}()
+	<-syncStarted
+	select {
+	case err := <-syncDone:
+		t.Fatalf("config sync escaped the removal transaction: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseStage)
+	if err := <-removeDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-syncDone; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(source); !os.IsNotExist(err) {
+		t.Fatalf("removed account home was recreated: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destination, "codex-home", "config.toml")); err != nil {
+		t.Fatalf("staged backup was lost: %v", err)
 	}
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "check": "npm run check:go && npm run check:js && npm run check:python && npm run check:shell",
     "check:go": "go test ./... && go vet ./...",
-    "check:js": "node --check ui/account-menu.js && node --check ui/thread-subscription.js && node --check ui/ui-test-bridge.cjs",
+    "check:js": "node --check ui/account-menu.js && node --check ui/thread-subscription.js && node --check ui/ui-test-bridge.cjs && node --test ui/account-menu.test.cjs",
     "check:python": "python3 -m py_compile scripts/patch_app.py scripts/check_release.py",
     "check:shell": "bash -n install.sh",
     "release:check": "python3 scripts/check_release.py"

--- a/ui/account-menu.js
+++ b/ui/account-menu.js
@@ -23,6 +23,52 @@ async function codexMuxRequest(path, options = {}) {
   return body;
 }
 
+function codexMuxSubscribeToEvents(onEvent) {
+  const events = new EventSource(
+    `${CODEX_MUX_API}/events?token=${encodeURIComponent(CODEX_MUX_TOKEN)}`,
+  );
+  events.onmessage = (event) => {
+    try {
+      onEvent(JSON.parse(event.data));
+    } catch {}
+  };
+  return () => events.close();
+}
+
+function codexMuxConnectedAccounts(accounts) {
+  return accounts.filter((account) => account.connected && account.enabled);
+}
+
+function codexMuxMenuAccounts(accounts, managing) {
+  return managing ? accounts : codexMuxConnectedAccounts(accounts);
+}
+
+function codexMuxSelectRemoval(event, account, setPendingRemoval, setRemovalError) {
+  event.preventDefault();
+  if (account.controller) return;
+  setRemovalError("");
+  setPendingRemoval(account);
+}
+
+function codexMuxPluginAccounts(accounts) {
+  return codexMuxConnectedAccounts(accounts);
+}
+
+function codexMuxNextPluginAccountId(accounts, currentId) {
+  return accounts.some((account) => account.id === currentId)
+    ? currentId
+    : accounts[0]?.id || "primary";
+}
+
+function codexMuxInvalidatePluginQueries(queryClient) {
+  return queryClient.invalidateQueries({
+    predicate: (query) => {
+      const root = query.queryKey?.[0];
+      return root === "apps" || root === "plugins" || root === "mcp";
+    },
+  });
+}
+
 const CODEX_MUX_ACCOUNT_SCOPED_PLUGIN_METHODS = new Set([
   "list-apps",
   "list-installed-apps",
@@ -243,9 +289,7 @@ function CodexMuxAccountMenu() {
     try {
       const result = await codexMuxRequest("/accounts");
       const nextAccounts = result.accounts || [];
-      globalThis.__codexMuxConnectedAccounts = nextAccounts.filter(
-        (account) => account.connected && account.enabled,
-      );
+      globalThis.__codexMuxConnectedAccounts = codexMuxConnectedAccounts(nextAccounts);
       setAccounts(nextAccounts);
       setError("");
       if (nextAccounts.some((account) => account.connected)) setLoading(false);
@@ -257,23 +301,17 @@ function CodexMuxAccountMenu() {
 
   kXc.useEffect(() => {
     refresh();
-    const events = new EventSource(
-      `${CODEX_MUX_API}/events?token=${encodeURIComponent(CODEX_MUX_TOKEN)}`,
-    );
-    events.onmessage = (event) => {
-      try {
-        const payload = JSON.parse(event.data);
-        if (
-          payload.type === "account-updated" &&
-          payload.accountId === loginAccountId
-        ) {
-          codexMuxLoginActive = false;
-          setLogin(null);
-        }
-        if (payload.type === "account-updated") refresh();
-        if (payload.type === "account-removed") refresh();
-      } catch {}
-    };
+    const unsubscribe = codexMuxSubscribeToEvents((payload) => {
+      if (
+        payload.type === "account-updated" &&
+        payload.accountId === loginAccountId
+      ) {
+        codexMuxLoginActive = false;
+        setLogin(null);
+      }
+      if (payload.type === "account-updated") refresh();
+      if (payload.type === "account-removed") refresh();
+    });
     const warmupTimer = setTimeout(refresh, 2_000);
     const loadingDeadline = setTimeout(() => {
       refresh().finally(() => setLoading(false));
@@ -283,7 +321,7 @@ function CodexMuxAccountMenu() {
       clearTimeout(warmupTimer);
       clearTimeout(loadingDeadline);
       clearInterval(timer);
-      events.close();
+      unsubscribe();
     };
   }, [refresh, loginAccountId]);
 
@@ -300,9 +338,8 @@ function CodexMuxAccountMenu() {
     return () => window.removeEventListener("keydown", allowEscapeDismissal, true);
   }, [login, managing, pendingRemoval]);
 
-  const connected = accounts.filter(
-    (account) => account.connected && account.enabled,
-  );
+  const connected = codexMuxConnectedAccounts(accounts);
+  const menuAccounts = codexMuxMenuAccounts(accounts, managing);
   const weeklyWindows = connected.map((account) =>
     codexMuxWeeklyWindow(account.rateLimits),
   );
@@ -430,13 +467,13 @@ function CodexMuxAccountMenu() {
       "codex-mux-total",
     ),
   );
-  if (connected.length > 0) {
+  if (menuAccounts.length > 0) {
     rows.push(
       (0, e7.jsx)(CH.Separator, {}, "codex-mux-accounts-separator"),
     );
   }
 
-  for (const account of connected) {
+  for (const account of menuAccounts) {
     const weekly = codexMuxWeeklyWindow(account.rateLimits);
     const remaining = weekly == null ? null : Math.max(0, 100 - weekly.usedPercent);
     rows.push(
@@ -449,12 +486,22 @@ function CodexMuxAccountMenu() {
               imageUrl: account.profileImageUrl,
               label: account.label,
             }),
-          SubText: account.email
-            ? (0, e7.jsx)(CodexMuxMaskedEmail, { email: account.email })
-            : account.planType || "ChatGPT subscription",
+          SubText: !account.enabled
+            ? "Disabled subscription"
+            : !account.connected
+              ? "Not connected"
+              : account.email
+                ? (0, e7.jsx)(CodexMuxMaskedEmail, { email: account.email })
+                : account.planType || "ChatGPT subscription",
           className: "group",
-          onSelect: managing && !account.controller
-            ? () => setPendingRemoval(account)
+          onSelect: managing
+            ? (event) =>
+                codexMuxSelectRemoval(
+                  event,
+                  account,
+                  setPendingRemoval,
+                  setRemovalError,
+                )
             : undefined,
           rightIcon: managing
             ? (0, e7.jsx)("span", {
@@ -503,7 +550,10 @@ function CodexMuxAccountMenu() {
       (0, e7.jsx)(
         _H,
         {
-          onSelect: () => setPendingRemoval(null),
+          onSelect: (event) => {
+            event.preventDefault();
+            setPendingRemoval(null);
+          },
           children: "Cancel",
         },
         "codex-mux-remove-cancel",
@@ -577,7 +627,7 @@ function CodexMuxAccountMenu() {
       ),
     );
   }
-  if (!loading && connected.length > 0) {
+  if (!loading && accounts.some((account) => !account.controller)) {
     rows.push(
       (0, e7.jsx)(
         _H,
@@ -802,25 +852,34 @@ function CodexMuxPluginScope() {
   const [selectedId, setSelectedId] = kXc.useState("primary");
   const [loading, setLoading] = kXc.useState(true);
   const queryClient = lt();
+  const refreshAccounts = kXc.useCallback(async (removedAccountId = null) => {
+    const result = await codexMuxRequest("/accounts");
+    const nextAccounts = codexMuxPluginAccounts(result.accounts || []);
+    const currentId = globalThis.__codexMuxPluginAccountId || "primary";
+    const nextId = codexMuxNextPluginAccountId(nextAccounts, currentId);
+    globalThis.__codexMuxPluginAccountId = nextId;
+    setAccounts(nextAccounts);
+    setSelectedId(nextId);
+    setLoading(false);
+    if (removedAccountId === currentId || nextId !== currentId) {
+      await codexMuxInvalidatePluginQueries(queryClient);
+    }
+  }, [queryClient]);
+
   kXc.useEffect(() => {
     let live = true;
-    codexMuxRequest("/accounts")
-      .then((result) => {
-        if (!live) return;
-        setAccounts(
-          (result.accounts || []).filter(
-            (account) => account.connected && account.enabled,
-          ),
-        );
-      })
-      .catch(() => {})
-      .finally(() => {
-        if (live) setLoading(false);
-      });
+    refreshAccounts().catch(() => {
+      if (live) setLoading(false);
+    });
+    const unsubscribe = codexMuxSubscribeToEvents((payload) => {
+      if (payload.type !== "account-removed" || !live) return;
+      refreshAccounts(payload.accountId).catch(() => {});
+    });
     return () => {
       live = false;
+      unsubscribe();
     };
-  }, []);
+  }, [refreshAccounts]);
 
   kXc.useEffect(() => {
     globalThis.__codexMuxPluginAccountId = selectedId;
@@ -833,12 +892,7 @@ function CodexMuxPluginScope() {
     if (accountId === selectedId) return;
     globalThis.__codexMuxPluginAccountId = accountId;
     setSelectedId(accountId);
-    await queryClient.invalidateQueries({
-      predicate: (query) => {
-        const root = query.queryKey?.[0];
-        return root === "apps" || root === "plugins" || root === "mcp";
-      },
-    });
+    await codexMuxInvalidatePluginQueries(queryClient);
   }
 
   const selected =

--- a/ui/account-menu.js
+++ b/ui/account-menu.js
@@ -234,6 +234,9 @@ function CodexMuxAccountMenu() {
   const [error, setError] = kXc.useState("");
   const [login, setLogin] = kXc.useState(null);
   const [codeCopied, setCodeCopied] = kXc.useState(false);
+  const [managing, setManaging] = kXc.useState(false);
+  const [pendingRemoval, setPendingRemoval] = kXc.useState(null);
+  const [removalError, setRemovalError] = kXc.useState("");
   const loginAccountId = login?.accountId || null;
 
   const refresh = kXc.useCallback(async () => {
@@ -268,6 +271,7 @@ function CodexMuxAccountMenu() {
           setLogin(null);
         }
         if (payload.type === "account-updated") refresh();
+        if (payload.type === "account-removed") refresh();
       } catch {}
     };
     const warmupTimer = setTimeout(refresh, 2_000);
@@ -284,15 +288,17 @@ function CodexMuxAccountMenu() {
   }, [refresh, loginAccountId]);
 
   kXc.useEffect(() => {
-    if (!login) return;
+    if (!login && !managing && !pendingRemoval) return;
     const allowEscapeDismissal = (event) => {
       if (event.key !== "Escape") return;
       codexMuxLoginActive = false;
       setLogin(null);
+      setPendingRemoval(null);
+      setManaging(false);
     };
     window.addEventListener("keydown", allowEscapeDismissal, true);
     return () => window.removeEventListener("keydown", allowEscapeDismissal, true);
-  }, [login]);
+  }, [login, managing, pendingRemoval]);
 
   const connected = accounts.filter(
     (account) => account.connected && account.enabled,
@@ -365,6 +371,40 @@ function CodexMuxAccountMenu() {
     }
   }
 
+  function startManaging(event) {
+    event.preventDefault();
+    setPendingRemoval(null);
+    setRemovalError("");
+    setManaging(true);
+  }
+
+  function exitManaging(event) {
+    event.preventDefault();
+    setPendingRemoval(null);
+    setRemovalError("");
+    setManaging(false);
+  }
+
+  async function removeSubscription(event) {
+    event.preventDefault();
+    if (busy || !pendingRemoval) return;
+    setBusy(true);
+    setRemovalError("");
+    try {
+      await codexMuxRequest(
+        `/accounts/${encodeURIComponent(pendingRemoval.id)}`,
+        { method: "DELETE" },
+      );
+      setPendingRemoval(null);
+      setManaging(false);
+      await refresh();
+    } catch (requestError) {
+      setRemovalError(requestError.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
   const rows = [];
   rows.push(
     (0, e7.jsx)(
@@ -413,15 +453,77 @@ function CodexMuxAccountMenu() {
             ? (0, e7.jsx)(CodexMuxMaskedEmail, { email: account.email })
             : account.planType || "ChatGPT subscription",
           className: "group",
-          rightIcon: (0, e7.jsx)("span", {
-            className: "text-token-description-foreground tabular-nums",
-            children: remaining == null ? "–" : `${Math.round(remaining)}%`,
-          }),
+          onSelect: managing && !account.controller
+            ? () => setPendingRemoval(account)
+            : undefined,
+          rightIcon: managing
+            ? (0, e7.jsx)("span", {
+                className: [
+                  "text-xs font-medium",
+                  account.controller
+                    ? "text-token-description-foreground"
+                    : "text-token-text-primary",
+                ].join(" "),
+                children: account.controller ? "Primary" : "Remove",
+              })
+            : (0, e7.jsx)("span", {
+                className: "text-token-description-foreground tabular-nums",
+                children: remaining == null ? "–" : `${Math.round(remaining)}%`,
+              }),
           children: account.planLabel
             ? `${account.label} · ${account.planLabel}`
             : account.label,
         },
         `codex-mux-account-${account.id}`,
+      ),
+    );
+  }
+
+  if (pendingRemoval) {
+    const pendingLabel = pendingRemoval.planLabel
+      ? `${pendingRemoval.label} · ${pendingRemoval.planLabel}`
+      : pendingRemoval.label;
+    rows.push(
+      (0, e7.jsx)(
+        _H,
+        {
+          LeftIcon: S2,
+          SubText:
+            "Its chats leave this app immediately; the account data is kept in a local backup",
+          tone: "danger",
+          allowWrap: true,
+          subTextAllowWrap: true,
+          onSelect: removeSubscription,
+          children: busy ? "Removing…" : `Remove ${pendingLabel} from this Mac`,
+        },
+        "codex-mux-remove-confirm",
+      ),
+    );
+    rows.push(
+      (0, e7.jsx)(
+        _H,
+        {
+          onSelect: () => setPendingRemoval(null),
+          children: "Cancel",
+        },
+        "codex-mux-remove-cancel",
+      ),
+    );
+  }
+
+  if (removalError) {
+    rows.push(
+      (0, e7.jsx)(
+        _H,
+        {
+          LeftIcon: S2,
+          SubText: removalError,
+          tone: "danger",
+          allowWrap: true,
+          subTextAllowWrap: true,
+          children: "Could not remove subscription",
+        },
+        "codex-mux-remove-error",
       ),
     );
   }
@@ -472,6 +574,18 @@ function CodexMuxAccountMenu() {
           children: busy ? "Adding subscription…" : "Add another subscription",
         },
         "codex-mux-add",
+      ),
+    );
+  }
+  if (!loading && connected.length > 0) {
+    rows.push(
+      (0, e7.jsx)(
+        _H,
+        {
+          onSelect: managing ? exitManaging : startManaging,
+          children: managing ? "Done" : "Manage subscriptions",
+        },
+        managing ? "codex-mux-manage-done" : "codex-mux-manage",
       ),
     );
   }

--- a/ui/account-menu.test.cjs
+++ b/ui/account-menu.test.cjs
@@ -1,0 +1,123 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+function loadHelpers(overrides = {}) {
+  const source = fs.readFileSync(path.join(__dirname, "account-menu.js"), "utf8");
+  const context = { ...overrides };
+  vm.runInNewContext(
+    `${source}\n;globalThis.__codexMuxTest = {
+      codexMuxSubscribeToEvents,
+      codexMuxConnectedAccounts,
+      codexMuxMenuAccounts,
+      codexMuxSelectRemoval,
+      codexMuxPluginAccounts,
+      codexMuxNextPluginAccountId,
+      codexMuxInvalidatePluginQueries,
+    };`,
+    context,
+  );
+  return { context, helpers: context.__codexMuxTest };
+}
+
+test("manage mode exposes disconnected and disabled subscriptions", () => {
+  const { helpers } = loadHelpers();
+  const accounts = [
+    { id: "primary", controller: true, connected: true, enabled: true },
+    { id: "connected", connected: true, enabled: true },
+    { id: "disconnected", connected: false, enabled: true },
+    { id: "disabled", connected: true, enabled: false },
+  ];
+
+  assert.deepEqual(
+    Array.from(helpers.codexMuxMenuAccounts(accounts, false), (account) => account.id),
+    ["primary", "connected"],
+  );
+  assert.deepEqual(
+    Array.from(helpers.codexMuxMenuAccounts(accounts, true), (account) => account.id),
+    ["primary", "connected", "disconnected", "disabled"],
+  );
+});
+
+test("removal selection keeps the menu open and rejects Primary", () => {
+  const { helpers } = loadHelpers();
+  let prevented = 0;
+  let pending = null;
+  let removalError = "previous failure";
+  const event = { preventDefault: () => { prevented += 1; } };
+  const setPending = (account) => { pending = account; };
+  const setError = (message) => { removalError = message; };
+
+  helpers.codexMuxSelectRemoval(
+    event,
+    { id: "disconnected", connected: false, enabled: false },
+    setPending,
+    setError,
+  );
+  assert.equal(prevented, 1);
+  assert.equal(pending.id, "disconnected");
+  assert.equal(removalError, "");
+
+  pending = null;
+  helpers.codexMuxSelectRemoval(
+    event,
+    { id: "primary", controller: true },
+    setPending,
+    setError,
+  );
+  assert.equal(prevented, 2);
+  assert.equal(pending, null);
+});
+
+test("plugin scope falls back after its selected account is removed", async () => {
+  const { helpers } = loadHelpers();
+  const remaining = [
+    { id: "primary", connected: true, enabled: true },
+    { id: "other", connected: true, enabled: true },
+  ];
+  assert.equal(
+    helpers.codexMuxNextPluginAccountId(remaining, "removed"),
+    "primary",
+  );
+  assert.equal(
+    helpers.codexMuxNextPluginAccountId(remaining, "other"),
+    "other",
+  );
+
+  let predicate;
+  await helpers.codexMuxInvalidatePluginQueries({
+    invalidateQueries: async (options) => { predicate = options.predicate; },
+  });
+  assert.equal(predicate({ queryKey: ["apps"] }), true);
+  assert.equal(predicate({ queryKey: ["plugins"] }), true);
+  assert.equal(predicate({ queryKey: ["mcp"] }), true);
+  assert.equal(predicate({ queryKey: ["unrelated"] }), false);
+});
+
+test("event subscription delivers removal payloads and closes cleanly", () => {
+  let source;
+  class FakeEventSource {
+    constructor(url) {
+      this.url = url;
+      this.closed = false;
+      source = this;
+    }
+    close() {
+      this.closed = true;
+    }
+  }
+  const { helpers } = loadHelpers({ EventSource: FakeEventSource });
+  const payloads = [];
+  const unsubscribe = helpers.codexMuxSubscribeToEvents((payload) => payloads.push(payload));
+  source.onmessage({ data: JSON.stringify({ type: "account-removed", accountId: "work" }) });
+  source.onmessage({ data: "not json" });
+  assert.equal(source.url.includes("/events?token="), true);
+  assert.equal(payloads.length, 1);
+  assert.equal(payloads[0].accountId, "work");
+  unsubscribe();
+  assert.equal(source.closed, true);
+});


### PR DESCRIPTION
## Summary

- Adds end-to-end subscription removal, which the native account menu had no way to do once a subscription was connected: `Store.RemoveAccount` (state + thread-owner cleanup) → `Multiplexer.RemoveAccount` (child teardown, recoverable backup, `account-removed` event) → `DELETE /v1/accounts/{id}` → a manage mode in the injected account menu.
- The UI follows the iOS pattern of a destructive action that never leaves the menu: **Manage subscriptions** switches account rows into removal mode (the Primary row shows a non-actionable label and cannot be selected), selecting a subscription reveals a second confirmation row that spells out the real consequences ("chats leave this app immediately; account data is kept in a local backup"), with a Cancel row and Escape dismissal at every step.
- Removal is ordered to stay reversible until the state commit: stop the account's app-server child, move `~/.codex-mux/accounts/<id>` to `backups/accounts/<id>-<timestamp>` (credentials and history preserved, permissions intact), then commit the removal and publish `account-removed` so SSE listeners refresh immediately. Threads the removed account owned lose their owner and fall back to the controller account, matching the existing owner-miss path.
- README, CHANGELOG, and the ARCHITECTURE control-API action list are updated with the flow and the backup path.

## Verification

- [x] `npm run check` (go test ./..., go vet, node --check on all UI bundles, py_compile, bash -n)
- [x] `npm run release:check`
- [ ] Tested against the upstream build in `docs/COMPATIBILITY.md` — no renderer anchors were touched (the menu reuses the already-injected `_H` row component), but a live patched-app pass plus a curated screenshot of the manage/confirm state is still pending; happy to attach one after the next local rebuild.
- [x] No credentials, account data, app bundles, or unredacted device codes

New tests: `TestRemoveAccountClearsOwnershipAndPersists` (state), `TestRemoveAccountBacksUpHomeAndPublishesEvent` (mux), and the control package's first HTTP-level tests (`TestDeleteAccountRemovesSecondarySubscription`, `TestDeleteAccountRejectsPrimaryAndBadToken`) driving a real loopback server: delete → account gone from `GET /v1/accounts`, delete of `primary` → 400, bad token → 401.

## Security-sensitive changes

- New authenticated route `DELETE /v1/accounts/{id}` on the loopback-only control service, same constant-time token check and 64 KB body limits as existing routes; `DELETE` added to the CORS allow-methods list for the `app://-` origin. It accepts no request body and no path wildcarding beyond the existing account-ID segment; the Primary/controller account is rejected server-side, not just hidden in the UI.
- Removed account data (including its OAuth credentials) is moved, not deleted, to `~/.codex-mux/backups/accounts/<id>-<timestamp>` with owner-only directory permissions preserved; this location is now documented in README alongside the existing backups path. The control API never returns OAuth tokens, unchanged.
