### PR TITLE
Add cross-account chat continuity and subscription controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ this project uses [Semantic Versioning](https://semver.org/).
   rebuilds, recoverable upgrades, and automatic launch.
 - Reset-aware routing that prioritizes weekly quota at risk of expiring and
   gives a bounded boost to subscriptions with banked usage resets.
+- Shared rollout storage and thread indexing so router-created chats remain
+  discoverable by every subscription and the official app.
+- Manual per-chat subscription switching with active-turn and quota guards.
+- Automatic continuation on another account after a terminal usage-limit
+  failure.
+- Per-account five-hour and weekly usage, reset timestamps, and a native-style
+  selector in the pinned thread summary.
+- Fail-closed support for ChatGPT desktop builds `7303` and `7345`.
+
+### Changed
+
+- New-turn routing now excludes accounts whose five-hour or weekly window is
+  depleted.
+- Apple silicon is selected explicitly for the launcher and multiplexer build.
+
+### Fixed
+
+- Restricted push entitlements are removed from independently signed copies so
+  macOS does not terminate ad-hoc builds at launch.
+- Legacy isolated thread indexes are backed up and imported into the shared
+  primary index during upgrade.
 
 ## [0.1.0] - 2026-08-15
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Codex Subscription Router currently targets:
 | Component | Supported value |
 | --- | --- |
 | Platform | macOS on Apple silicon |
-| Official ChatGPT versions | `26.803.61601`, `26.825.32147` |
-| Official bundle builds | `6396`, `7303` |
+| Official ChatGPT versions | `26.803.61601`, `26.825.32147`, `26.825.41651` |
+| Official bundle builds | `6396`, `7303`, `7345` |
 | Go | 1.26 or newer |
 | Node.js | 22.12 or newer |
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ binaries or a prebuilt application.
 - **Quota-aware routing.** New chats favour weekly allowance that will expire
   sooner, with a bounded boost for accounts holding banked usage resets.
 - **Sticky conversations.** Once a thread is assigned, every follow-up returns
-  to the same subscription unless that subscription is depleted.
+  to the same subscription unless it is manually switched or depleted.
 - **Automatic failover.** A depleted thread continues through another account
   with quota; if the whole pool is empty, the app shows one combined alert.
+- **Shared chat history.** Rollouts and the thread index are visible to every
+  connected subscription and the official app, while credentials stay isolated.
+- **Per-chat switching.** The pinned thread summary can move an idle chat to
+  another connected subscription without creating a new conversation.
 - **Native account management.** The existing profile menu shows pooled usage,
   profile photos, plan names, masked emails, and device-code sign-in.
 - **Account-aware settings.** Profile statistics can be viewed together or per
@@ -73,8 +77,8 @@ Codex Subscription Router currently targets:
 | Component | Supported value |
 | --- | --- |
 | Platform | macOS on Apple silicon |
-| Official ChatGPT version | `26.803.61601` |
-| Official bundle build | `6396` |
+| Official ChatGPT versions | `26.803.61601`, `26.825.32147` |
+| Official bundle builds | `6396`, `7303` |
 | Go | 1.26 or newer |
 | Node.js | 22.12 or newer |
 
@@ -184,9 +188,9 @@ request Automation access the first time Computer Use controls another app.
 While the code is visible, clicking away does not dismiss the menu. Clicking
 the code copies it and opens the verification page.
 
-The profile menu displays combined weekly usage followed by one row per
-subscription. Email addresses remain masked until hovered. The final row always
-starts another sign-in.
+The profile menu displays combined usage followed by one row per subscription.
+Each row shows both five-hour and weekly usage with reset times. Email addresses
+remain masked until hovered. The final row always starts another sign-in.
 
 ## Routing behavior
 
@@ -194,6 +198,7 @@ starts another sign-in.
 | --- | --- |
 | New chat | Assigned by quota-at-risk, banked resets, and short-window pressure |
 | Follow-up | Sent to the thread's persisted account owner |
+| Manual switch | Resumes an idle chat on the selected subscription |
 | Owner depleted | Continued through another account with capacity |
 | Every account depleted | Combined quota alert with the next known reset |
 | Account disabled | Excluded from routing and pooled usable quota |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,7 +15,9 @@ with a small Go multiplexer and keeps the original binary beside it as
 
 The desktop app opens one JSON-RPC app-server connection to the multiplexer.
 The multiplexer starts one real app-server child for every enabled account,
-each with its own `CODEX_HOME` and `CODEX_SQLITE_HOME`.
+each with its own credential-bearing `CODEX_HOME`. All children use the Primary
+account's `CODEX_SQLITE_HOME`, so one thread index is visible to both desktop
+apps.
 
 New threads are assigned using a quota-urgency score: weekly percentage
 remaining divided by the hours until that account resets. Banked usage resets
@@ -27,15 +29,19 @@ approvals, and notifications are rewritten only as needed to preserve one
 coherent desktop session.
 
 If the owner is depleted, the multiplexer resumes the rollout on an account
-with capacity and updates ownership. Threads do not migrate for ordinary load
-balancing.
+with capacity, starts a continuation turn, and updates ownership. An idle thread
+can also be switched explicitly from its pinned summary. Threads do not migrate
+for ordinary load balancing.
 
 ## Account isolation
 
 The Primary account uses `~/.codex`. Added accounts use
 `~/.codex-mux/accounts/<id>/codex-home`. Managed configuration is copied from
 the Primary account, excluding credential-store settings and project trust.
-Each isolated account forces file-backed CLI and MCP OAuth credentials.
+Each isolated account forces file-backed CLI and MCP OAuth credentials. Its
+`sessions` and `archived_sessions` paths link to the Primary rollout store;
+existing isolated rollouts are merged with collision checks and preserved
+backups before the links are installed.
 
 ## Desktop integration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -13,6 +13,18 @@ stops instead of applying a partial patch.
 | `app.asar` SHA-256 | `d5a44ed9e2f1db5f81dbbe85408aed256f3203c5b16f00817bb9d7cd941343cf` |
 | Architecture | Apple silicon (`arm64`) |
 
+## ChatGPT build 7303
+
+| Component | Tested value |
+| --- | --- |
+| Official ChatGPT version | `26.825.32147` |
+| Official bundle build | `7303` |
+| `app.asar` SHA-256 | `0462b03e878f0e78b223b849ee14cbba0de043f2c16acebee163cb95daa622ef` |
+| Architecture | Apple silicon (`arm64`) |
+
+Build 7303 regenerates the renderer bundles and uses a dedicated, fail-closed
+set of native UI anchors. The original build 6396 patch remains supported.
+
 A different official version may work when all anchors remain identical, but
 it is unverified. The patcher rejects a version, build, or ASAR hash mismatch by
 default; `--allow-untested-source` is an explicit diagnostic override. Never

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -15,6 +15,8 @@ stops instead of applying a partial patch.
 
 ## ChatGPT build 7303
 
+### Build 7303
+
 | Component | Tested value |
 | --- | --- |
 | Official ChatGPT version | `26.825.32147` |
@@ -24,6 +26,19 @@ stops instead of applying a partial patch.
 
 Build 7303 regenerates the renderer bundles and uses a dedicated, fail-closed
 set of native UI anchors. The original build 6396 patch remains supported.
+
+### Build 7345
+
+| Component | Tested value |
+| --- | --- |
+| Official ChatGPT version | `26.825.41651` |
+| Official bundle build | `7345` |
+| `app.asar` SHA-256 | `c089b63abb7ca4a751072c0da434248db13c32bed9c363e1b7e5428584b0576d` |
+| Architecture | Apple silicon (`arm64`) |
+
+Build 7345 retains the reviewed build-7303 renderer anchors. The full patch,
+repack, signing, and signature verification flow was repeated against this
+exact ASAR.
 
 A different official version may work when all anchors remain identical, but
 it is unverified. The patcher rejects a version, build, or ASAR hash mismatch by

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -19,6 +19,11 @@ profile and rate-limit-reset endpoints used by the desktop experience. It does
 not log or return tokens. State persisted by the mux contains account paths,
 labels, enabled state, and thread ownership only.
 
+Conversation rollout files and the SQLite thread index are deliberately shared
+between account children. This enables cross-account continuation and lets the
+official app discover router-created chats. The shared store contains chat
+history, but not the per-account `auth.json` credential files.
+
 The state root is mode `0700`; state, config, and control-token files are mode
 `0600`. Existing control tokens are validated as 256-bit hexadecimal values and
 their permissions are repaired on startup.

--- a/internal/backend/child.go
+++ b/internal/backend/child.go
@@ -28,7 +28,9 @@ type response struct {
 	err     error
 }
 
-// Child owns one real Codex app-server process and one isolated CODEX_HOME.
+// Child owns one real Codex app-server process and one isolated credential
+// home. All children use the primary SQLite home so every client can discover
+// the same thread index.
 type Child struct {
 	accountID string
 	exe       string
@@ -46,9 +48,8 @@ type Child struct {
 	closeOnce sync.Once
 }
 
-func Start(accountID, codexHome, executable string, args, baseEnv []string, inbound chan<- Inbound) (*Child, error) {
-	env := withEnvironment(baseEnv, "CODEX_HOME", codexHome)
-	env = withEnvironment(env, "CODEX_SQLITE_HOME", codexHome)
+func Start(accountID, codexHome, sqliteHome, executable string, args, baseEnv []string, inbound chan<- Inbound) (*Child, error) {
+	env := childEnvironment(baseEnv, codexHome, sqliteHome)
 	command := exec.Command(executable, args...)
 	command.Env = env
 	stdin, err := command.StdinPipe()
@@ -78,6 +79,11 @@ func Start(accountID, codexHome, executable string, args, baseEnv []string, inbo
 	go child.readLoop(stdout)
 	go child.waitLoop()
 	return child, nil
+}
+
+func childEnvironment(baseEnv []string, codexHome, sqliteHome string) []string {
+	env := withEnvironment(baseEnv, "CODEX_HOME", codexHome)
+	return withEnvironment(env, "CODEX_SQLITE_HOME", sqliteHome)
 }
 
 func (c *Child) AccountID() string {

--- a/internal/backend/child_test.go
+++ b/internal/backend/child_test.go
@@ -1,0 +1,27 @@
+package backend
+
+import "testing"
+
+func TestChildEnvironmentIsolatesCredentialsAndSharesThreadIndex(t *testing.T) {
+	environment := childEnvironment(
+		[]string{"PATH=/usr/bin", "CODEX_HOME=old", "CODEX_SQLITE_HOME=old"},
+		"/isolated/account",
+		"/primary/codex",
+	)
+	want := map[string]string{
+		"CODEX_HOME":        "/isolated/account",
+		"CODEX_SQLITE_HOME": "/primary/codex",
+	}
+	for key, value := range want {
+		found := false
+		for _, entry := range environment {
+			if entry == key+"="+value {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("missing %s=%s in %#v", key, value, environment)
+		}
+	}
+}

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -119,20 +119,42 @@ func (s *Server) threadAccount(response http.ResponseWriter, request *http.Reque
 		writeJSON(response, http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
 		return
 	}
-	if request.Method != http.MethodGet {
+	threadID := strings.TrimSpace(request.URL.Query().Get("threadId"))
+	accountID := ""
+	if request.Method == http.MethodPost {
+		var input struct {
+			ThreadID  string `json:"threadId"`
+			AccountID string `json:"accountId"`
+		}
+		if err := decodeJSON(request, &input); err != nil {
+			writeJSON(response, http.StatusBadRequest, map[string]any{"error": err.Error()})
+			return
+		}
+		threadID = strings.TrimSpace(input.ThreadID)
+		accountID = strings.TrimSpace(input.AccountID)
+	} else if request.Method != http.MethodGet {
 		methodNotAllowed(response)
 		return
 	}
-	threadID := strings.TrimSpace(request.URL.Query().Get("threadId"))
 	if threadID == "" {
 		writeJSON(response, http.StatusBadRequest, map[string]any{"error": "threadId is required"})
 		return
 	}
 	ctx, cancel := context.WithTimeout(request.Context(), 20*time.Second)
 	defer cancel()
-	account, err := s.mux.ThreadAccount(ctx, threadID)
+	var account mux.AccountSnapshot
+	var err error
+	if request.Method == http.MethodPost {
+		account, err = s.mux.SwitchThreadAccount(ctx, threadID, accountID)
+	} else {
+		account, err = s.mux.ThreadAccount(ctx, threadID)
+	}
 	if err != nil {
-		writeJSON(response, http.StatusNotFound, map[string]any{"error": err.Error()})
+		status := http.StatusBadRequest
+		if request.Method == http.MethodGet {
+			status = http.StatusNotFound
+		}
+		writeJSON(response, status, map[string]any{"error": err.Error()})
 		return
 	}
 	writeJSON(response, http.StatusOK, map[string]any{"account": account})

--- a/internal/mux/accounts.go
+++ b/internal/mux/accounts.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/b-nnett/codex-subscription-router/internal/state"
@@ -122,6 +123,52 @@ func (m *Multiplexer) ThreadAccount(ctx context.Context, threadID string) (Accou
 		return AccountSnapshot{}, fmt.Errorf("thread %q has no subscription assignment", threadID)
 	}
 	return m.accountSnapshotWithProfile(ctx, accountID, true)
+}
+
+// SwitchThreadAccount resumes an existing chat on another subscription while
+// preserving its thread ID and rollout history.
+func (m *Multiplexer) SwitchThreadAccount(ctx context.Context, threadID, targetAccountID string) (AccountSnapshot, error) {
+	threadID = strings.TrimSpace(threadID)
+	targetAccountID = strings.TrimSpace(targetAccountID)
+	if threadID == "" || targetAccountID == "" {
+		return AccountSnapshot{}, errors.New("threadId and accountId are required")
+	}
+	sourceAccountID, ok := m.store.ThreadOwner(threadID)
+	if !ok {
+		return AccountSnapshot{}, fmt.Errorf("thread %q has no subscription assignment", threadID)
+	}
+	target, err := m.accountSnapshotWithProfile(ctx, targetAccountID, true)
+	if err != nil {
+		return AccountSnapshot{}, err
+	}
+	if !target.Enabled || !target.Connected || target.AuthType != "chatgpt" {
+		return AccountSnapshot{}, fmt.Errorf("subscription %q is not available", target.Label)
+	}
+	if !accountHasCapacity(target) {
+		return AccountSnapshot{}, fmt.Errorf("subscription %q has no usage remaining", target.Label)
+	}
+	if sourceAccountID == targetAccountID {
+		return target, nil
+	}
+	m.activeTurnsMu.Lock()
+	_, active := m.activeTurns[threadID]
+	m.activeTurnsMu.Unlock()
+	if active {
+		return AccountSnapshot{}, errors.New("wait for the current turn to finish before switching subscriptions")
+	}
+	if err := m.resumeThreadOnAccount(ctx, threadID, sourceAccountID, targetAccountID); err != nil {
+		return AccountSnapshot{}, err
+	}
+	if err := m.store.SetThreadOwner(threadID, targetAccountID); err != nil {
+		return AccountSnapshot{}, err
+	}
+	m.publish(Event{
+		Type:      "thread-account-changed",
+		AccountID: targetAccountID,
+		Message:   fmt.Sprintf("Chat moved to %s", target.Label),
+		Data:      map[string]any{"threadId": threadID, "previousAccountId": sourceAccountID},
+	})
+	return target, nil
 }
 
 func (m *Multiplexer) StartLogin(ctx context.Context, id, mode string) (json.RawMessage, error) {
@@ -262,7 +309,7 @@ func (m *Multiplexer) chooseAccountExcluding(ctx context.Context, excluded map[s
 			continue
 		}
 		weekly, short := longestAndShortestWindow(snapshot.RateLimits)
-		if weekly != nil && weekly.UsedPercent >= 100 {
+		if windowDepleted(weekly) || windowDepleted(short) {
 			continue
 		}
 		weeklyUsed := 1_000.0
@@ -398,8 +445,8 @@ func aggregateRateLimits(snapshots []AccountSnapshot) (*RateLimits, error) {
 			primary = append(primary, snapshot.RateLimits.Primary)
 			secondary = append(secondary, snapshot.RateLimits.Secondary)
 		}
-		weekly, _ := longestAndShortestWindow(snapshot.RateLimits)
-		if weekly == nil || weekly.UsedPercent < 100 {
+		weekly, short := longestAndShortestWindow(snapshot.RateLimits)
+		if !windowDepleted(weekly) && !windowDepleted(short) {
 			hasCapacity = true
 		}
 	}
@@ -472,6 +519,10 @@ func duration(window *RateLimitWindow) int64 {
 		return 0
 	}
 	return *window.WindowDurationMins
+}
+
+func windowDepleted(window *RateLimitWindow) bool {
+	return window != nil && window.UsedPercent >= 100
 }
 
 func contextWithControlTimeout(parent context.Context) (context.Context, context.CancelFunc) {

--- a/internal/mux/accounts_test.go
+++ b/internal/mux/accounts_test.go
@@ -93,6 +93,43 @@ func TestAggregateRateLimitsReportsAllDepleted(t *testing.T) {
 	}
 }
 
+func TestAccountCapacityRequiresFiveHourCapacity(t *testing.T) {
+	shortMinutes := int64(300)
+	weeklyMinutes := int64(10_080)
+	snapshot := AccountSnapshot{
+		Enabled: true, Connected: true, AuthType: "chatgpt",
+		RateLimits: &RateLimits{
+			Primary:   &RateLimitWindow{UsedPercent: 100, WindowDurationMins: &shortMinutes},
+			Secondary: &RateLimitWindow{UsedPercent: 20, WindowDurationMins: &weeklyMinutes},
+		},
+	}
+	if accountHasCapacity(snapshot) {
+		t.Fatal("account with a depleted five-hour window must not receive another turn")
+	}
+}
+
+func TestAggregateRateLimitsReportsFiveHourPoolDepleted(t *testing.T) {
+	shortMinutes := int64(300)
+	weeklyMinutes := int64(10_080)
+	snapshots := []AccountSnapshot{
+		{ID: "one", Enabled: true, Connected: true, AuthType: "chatgpt", RateLimits: &RateLimits{
+			Primary:   &RateLimitWindow{UsedPercent: 100, WindowDurationMins: &shortMinutes},
+			Secondary: &RateLimitWindow{UsedPercent: 20, WindowDurationMins: &weeklyMinutes},
+		}},
+		{ID: "two", Enabled: true, Connected: true, AuthType: "chatgpt", RateLimits: &RateLimits{
+			Primary:   &RateLimitWindow{UsedPercent: 100, WindowDurationMins: &shortMinutes},
+			Secondary: &RateLimitWindow{UsedPercent: 40, WindowDurationMins: &weeklyMinutes},
+		}},
+	}
+	limits, err := aggregateRateLimits(snapshots)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if limits.RateLimitReachedType != "rate_limit_reached" {
+		t.Fatalf("expected five-hour depletion to block the pool, got %#v", limits)
+	}
+}
+
 func TestRouteUrgencyPrefersQuotaExpiringSooner(t *testing.T) {
 	now := time.Date(2026, time.August, 16, 12, 0, 0, 0, time.UTC)
 	weeklyMinutes := int64(10_080)

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -41,6 +41,12 @@ type serverRequestRoute struct {
 	original  json.RawMessage
 }
 
+type activeTurn struct {
+	accountID string
+	message   protocol.Message
+	excluded  map[string]struct{}
+}
+
 type Event struct {
 	Type      string `json:"type"`
 	AccountID string `json:"accountId,omitempty"`
@@ -67,6 +73,8 @@ type Multiplexer struct {
 
 	externalMu     sync.Mutex
 	externalRoutes map[string]externalRoute
+	activeTurnsMu  sync.Mutex
+	activeTurns    map[string]activeTurn
 	serverMu       sync.Mutex
 	serverRoutes   map[string]serverRequestRoute
 	serverSequence atomic.Uint64
@@ -104,6 +112,7 @@ func New(options Options) (*Multiplexer, error) {
 		children:             make(map[string]*backend.Child),
 		inbound:              make(chan backend.Inbound, 1024),
 		externalRoutes:       make(map[string]externalRoute),
+		activeTurns:          make(map[string]activeTurn),
 		serverRoutes:         make(map[string]serverRequestRoute),
 		events:               make(map[chan Event]struct{}),
 		profileClient:        &http.Client{Timeout: 10 * time.Second},
@@ -450,6 +459,17 @@ func (m *Multiplexer) handleInbound(inbound backend.Inbound) {
 				go m.retryTurnAfterUsageLimit(route, inbound.AccountID)
 				return
 			}
+			if route.method == "turn/start" && message.Error == nil {
+				if threadID := threadIDFromParams(route.message.Params); threadID != "" {
+					m.activeTurnsMu.Lock()
+					m.activeTurns[threadID] = activeTurn{
+						accountID: inbound.AccountID,
+						message:   route.message,
+						excluded:  cloneAccountSet(route.excluded),
+					}
+					m.activeTurnsMu.Unlock()
+				}
+			}
 			m.learnThreadOwner(route, inbound.AccountID, message.Result)
 			m.writeRaw(inbound.Raw)
 		}
@@ -468,6 +488,27 @@ func (m *Multiplexer) handleInbound(inbound backend.Inbound) {
 			_ = m.store.SetThreadOwner(threadID, inbound.AccountID)
 		}
 	}
+	if isTerminalUsageLimitNotification(message.Method, message.Params) {
+		threadID := notificationThreadID(message.Params)
+		m.activeTurnsMu.Lock()
+		active, ok := m.activeTurns[threadID]
+		if ok && active.accountID == inbound.AccountID {
+			delete(m.activeTurns, threadID)
+		}
+		m.activeTurnsMu.Unlock()
+		if ok && active.accountID == inbound.AccountID {
+			go m.continueAfterAsyncUsageLimit(threadID, active, inbound.AccountID)
+		}
+	}
+	if message.Method == "turn/completed" {
+		if threadID := notificationThreadID(message.Params); threadID != "" {
+			m.activeTurnsMu.Lock()
+			if tracked, exists := m.activeTurns[threadID]; exists && tracked.accountID == inbound.AccountID {
+				delete(m.activeTurns, threadID)
+			}
+			m.activeTurnsMu.Unlock()
+		}
+	}
 	if message.Method == "turn/completed" ||
 		message.Method == "account/login/completed" ||
 		message.Method == "account/updated" {
@@ -476,6 +517,58 @@ func (m *Multiplexer) handleInbound(inbound backend.Inbound) {
 	if m.shouldForwardNotification(inbound.AccountID, message.Method) {
 		m.writeRaw(inbound.Raw)
 	}
+}
+
+func (m *Multiplexer) continueAfterAsyncUsageLimit(threadID string, active activeTurn, exhaustedAccountID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*requestTimeout)
+	defer cancel()
+	excluded := cloneAccountSet(active.excluded)
+	if excluded == nil {
+		excluded = make(map[string]struct{})
+	}
+	excluded[exhaustedAccountID] = struct{}{}
+	fallback, _, err := m.chooseAccountExcluding(ctx, excluded)
+	if err != nil {
+		m.publish(Event{Type: "thread-failover-failed", AccountID: exhaustedAccountID, Message: err.Error(), Data: map[string]any{"threadId": threadID}})
+		return
+	}
+	if err := m.resumeThreadOnAccount(ctx, threadID, exhaustedAccountID, fallback.ID); err != nil {
+		m.publish(Event{Type: "thread-failover-failed", AccountID: exhaustedAccountID, Message: err.Error(), Data: map[string]any{"threadId": threadID}})
+		return
+	}
+	if err := m.store.SetThreadOwner(threadID, fallback.ID); err != nil {
+		return
+	}
+	params, err := automaticContinuationParams(active.message.Params)
+	if err != nil {
+		return
+	}
+	target, ok := m.child(fallback.ID)
+	if !ok {
+		return
+	}
+	m.activeTurnsMu.Lock()
+	m.activeTurns[threadID] = activeTurn{
+		accountID: fallback.ID,
+		message:   protocol.Message{Method: "turn/start", Params: params},
+		excluded:  excluded,
+	}
+	m.activeTurnsMu.Unlock()
+	if _, err := target.Request(ctx, "turn/start", params); err != nil {
+		m.activeTurnsMu.Lock()
+		if tracked, exists := m.activeTurns[threadID]; exists && tracked.accountID == fallback.ID {
+			delete(m.activeTurns, threadID)
+		}
+		m.activeTurnsMu.Unlock()
+		m.publish(Event{Type: "thread-failover-failed", AccountID: fallback.ID, Message: err.Error(), Data: map[string]any{"threadId": threadID}})
+		return
+	}
+	m.publish(Event{
+		Type:      "thread-failed-over",
+		AccountID: fallback.ID,
+		Message:   fmt.Sprintf("Chat automatically continued with %s", fallback.Label),
+		Data:      map[string]any{"threadId": threadID, "previousAccountId": exhaustedAccountID},
+	})
 }
 
 func (m *Multiplexer) forwardAggregatedRateLimitNotification(fallback []byte) {
@@ -602,6 +695,7 @@ func (m *Multiplexer) startChild(ctx context.Context, account state.Account) (*b
 	child, err := backend.Start(
 		account.ID,
 		account.CodexHome,
+		m.store.PrimaryCodexHome(),
 		m.realExecutable,
 		m.realArgs,
 		m.environment,
@@ -699,12 +793,19 @@ func threadIDFromNotification(params json.RawMessage) string {
 	return threadIDFromResult(params)
 }
 
+func notificationThreadID(params json.RawMessage) string {
+	if threadID := threadIDFromParams(params); threadID != "" {
+		return threadID
+	}
+	return threadIDFromNotification(params)
+}
+
 func accountHasCapacity(snapshot AccountSnapshot) bool {
 	if !snapshot.Enabled || !snapshot.Connected || snapshot.AuthType != "chatgpt" {
 		return false
 	}
-	weekly, _ := longestAndShortestWindow(snapshot.RateLimits)
-	return weekly == nil || weekly.UsedPercent < 100
+	weekly, short := longestAndShortestWindow(snapshot.RateLimits)
+	return !windowDepleted(weekly) && !windowDepleted(short)
 }
 
 func isUsageLimitResponse(message protocol.Message) bool {
@@ -719,14 +820,48 @@ func isUsageLimitResponse(message protocol.Message) bool {
 		strings.Contains(text, "quota")
 }
 
+func isTerminalUsageLimitNotification(method string, params json.RawMessage) bool {
+	if method != "error" || len(params) == 0 {
+		return false
+	}
+	var decoded struct {
+		WillRetry bool `json:"willRetry"`
+	}
+	if json.Unmarshal(params, &decoded) != nil || decoded.WillRetry {
+		return false
+	}
+	text := strings.ToLower(string(params))
+	return strings.Contains(text, "usage_limit") ||
+		strings.Contains(text, "usage limit") ||
+		strings.Contains(text, "rate_limit") ||
+		strings.Contains(text, "rate limit") ||
+		strings.Contains(text, "quota")
+}
+
+func automaticContinuationParams(original json.RawMessage) (json.RawMessage, error) {
+	var params map[string]any
+	if err := json.Unmarshal(original, &params); err != nil {
+		return nil, fmt.Errorf("decode interrupted turn: %w", err)
+	}
+	params["input"] = []map[string]any{{
+		"type": "text",
+		"text": "Continue the task from where the previous subscription stopped. Do not repeat completed work.",
+	}}
+	encoded, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("encode continuation turn: %w", err)
+	}
+	return encoded, nil
+}
+
 func (m *Multiplexer) allSubscriptionsDepleted(ctx context.Context, id json.RawMessage) protocol.Message {
 	var resetsAt *int64
 	if preview := m.currentRateLimitPreview(); preview != nil && preview.Mode.isAllDepleted() {
 		resetsAt = preview.ResetsAt
 	} else if limits, err := m.AggregatedRateLimits(ctx); err == nil {
-		weekly, _ := longestAndShortestWindow(limits)
-		if weekly != nil {
-			resetsAt = weekly.ResetsAt
+		_, short := longestAndShortestWindow(limits)
+		if short != nil {
+			resetsAt = short.ResetsAt
 		}
 	}
 	return allSubscriptionsDepleted(id, resetsAt)

--- a/internal/mux/routing_test.go
+++ b/internal/mux/routing_test.go
@@ -29,6 +29,51 @@ func TestIsUsageLimitResponseIgnoresUnrelatedError(t *testing.T) {
 	}
 }
 
+func TestUsageLimitNotificationRecognizesTerminalAsyncError(t *testing.T) {
+	params := json.RawMessage(`{
+		"threadId":"thread-1",
+		"willRetry":false,
+		"error":{"message":"usage limit reached","codexErrorInfo":"usage_limit_exceeded"}
+	}`)
+	if !isTerminalUsageLimitNotification("error", params) {
+		t.Fatal("expected terminal asynchronous usage error to trigger failover")
+	}
+	if got := notificationThreadID(params); got != "thread-1" {
+		t.Fatalf("notification thread ID = %q", got)
+	}
+}
+
+func TestUsageLimitNotificationIgnoresRetryableError(t *testing.T) {
+	params := json.RawMessage(`{"threadId":"thread-1","willRetry":true,"error":{"message":"rate limit"}}`)
+	if isTerminalUsageLimitNotification("error", params) {
+		t.Fatal("router must let Codex finish its own retry first")
+	}
+}
+
+func TestContinuationParamsKeepTurnSettingsAndReplaceInput(t *testing.T) {
+	original := json.RawMessage(`{
+		"threadId":"thread-1",
+		"model":"gpt-test",
+		"effort":"high",
+		"input":[{"type":"text","text":"original request"}]
+	}`)
+	params, err := automaticContinuationParams(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(params, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded["threadId"] != "thread-1" || decoded["model"] != "gpt-test" || decoded["effort"] != "high" {
+		t.Fatalf("turn settings were not preserved: %#v", decoded)
+	}
+	input, ok := decoded["input"].([]any)
+	if !ok || len(input) != 1 || input[0].(map[string]any)["text"] == "original request" {
+		t.Fatalf("original input was not replaced safely: %#v", decoded["input"])
+	}
+}
+
 func TestAllSubscriptionsDepletedUsesActionableMessage(t *testing.T) {
 	message := allSubscriptionsDepleted(json.RawMessage(`7`), nil)
 	if message.Error == nil || message.Error.Code != -32026 {

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -31,8 +31,9 @@ type persistedState struct {
 	ThreadOwner map[string]string `json:"threadOwner"`
 }
 
-// Store persists only routing metadata. OAuth credentials and conversation
-// databases remain inside each account's isolated Codex home.
+// Store persists routing metadata. OAuth credentials remain isolated; rollout
+// files and the SQLite thread index are shared with the primary Codex home so
+// the official app can resume chats created by every subscription.
 type Store struct {
 	mu               sync.RWMutex
 	root             string
@@ -92,6 +93,9 @@ func Open(root, primaryCodexHome string) (*Store, error) {
 		if samePath(account.CodexHome, primaryCodexHome) {
 			continue
 		}
+		if err := shareRolloutStorage(primaryCodexHome, account.CodexHome); err != nil {
+			return nil, fmt.Errorf("share account %q rollouts: %w", account.ID, err)
+		}
 		if err := syncIsolatedConfig(primaryCodexHome, account.CodexHome); err != nil {
 			return nil, fmt.Errorf("sync account %q config: %w", account.ID, err)
 		}
@@ -101,6 +105,10 @@ func Open(root, primaryCodexHome string) (*Store, error) {
 
 func (s *Store) Root() string {
 	return s.root
+}
+
+func (s *Store) PrimaryCodexHome() string {
+	return s.primaryCodexHome
 }
 
 // SyncManagedConfig propagates desktop-managed configuration (including
@@ -177,6 +185,9 @@ func (s *Store) AddAccount(label string) (Account, error) {
 	if err := syncIsolatedConfig(s.primaryCodexHome, codexHome); err != nil {
 		return Account{}, fmt.Errorf("write account config: %w", err)
 	}
+	if err := shareRolloutStorage(s.primaryCodexHome, codexHome); err != nil {
+		return Account{}, fmt.Errorf("share account rollouts: %w", err)
+	}
 
 	account := Account{
 		ID:        id,
@@ -190,6 +201,87 @@ func (s *Store) AddAccount(label string) (Account, error) {
 		return Account{}, err
 	}
 	return account, nil
+}
+
+func shareRolloutStorage(primaryCodexHome, isolatedCodexHome string) error {
+	for _, name := range []string{"sessions", "archived_sessions"} {
+		primaryPath := filepath.Join(primaryCodexHome, name)
+		isolatedPath := filepath.Join(isolatedCodexHome, name)
+		if err := os.MkdirAll(primaryPath, 0o700); err != nil {
+			return fmt.Errorf("create shared %s: %w", name, err)
+		}
+		info, err := os.Lstat(isolatedPath)
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			if err := os.Symlink(primaryPath, isolatedPath); err != nil {
+				return fmt.Errorf("link %s: %w", name, err)
+			}
+		case err != nil:
+			return fmt.Errorf("inspect %s: %w", name, err)
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := filepath.EvalSymlinks(isolatedPath)
+			if err != nil {
+				return fmt.Errorf("resolve %s link: %w", name, err)
+			}
+			resolvedPrimary, err := filepath.EvalSymlinks(primaryPath)
+			if err != nil {
+				return fmt.Errorf("resolve shared %s: %w", name, err)
+			}
+			if !samePath(target, resolvedPrimary) {
+				return fmt.Errorf("%s already links to %q", isolatedPath, target)
+			}
+		case info.IsDir():
+			if err := mergeTree(isolatedPath, primaryPath); err != nil {
+				return fmt.Errorf("migrate %s: %w", name, err)
+			}
+			backup := isolatedPath + ".codex-mux-backup-" + time.Now().Format("20060102T150405.000000000")
+			if err := os.Rename(isolatedPath, backup); err != nil {
+				return fmt.Errorf("preserve old %s: %w", name, err)
+			}
+			if err := os.Symlink(primaryPath, isolatedPath); err != nil {
+				_ = os.Rename(backup, isolatedPath)
+				return fmt.Errorf("link migrated %s: %w", name, err)
+			}
+		default:
+			return fmt.Errorf("%s is not a directory", isolatedPath)
+		}
+	}
+	return nil
+}
+
+func mergeTree(source, destination string) error {
+	return filepath.WalkDir(source, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(source, path)
+		if err != nil || relative == "." {
+			return err
+		}
+		target := filepath.Join(destination, relative)
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o700)
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing symlink inside rollout store: %s", path)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if existing, err := os.ReadFile(target); err == nil {
+			if slices.Equal(existing, data) {
+				return nil
+			}
+			return fmt.Errorf("rollout collision at %s", relative)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o600)
+	})
 }
 
 func (s *Store) UpdateAccount(id string, label *string, enabled *bool) (Account, error) {

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -172,3 +172,43 @@ func TestUpdateAccountPreservesController(t *testing.T) {
 		t.Fatalf("unexpected updated account: %#v", account)
 	}
 }
+
+func TestOpenSharesExistingAccountRolloutsWithPrimaryHome(t *testing.T) {
+	root := t.TempDir()
+	primaryHome := filepath.Join(root, "primary")
+	muxRoot := filepath.Join(root, "mux")
+	store, err := Open(muxRoot, primaryHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	account, err := store.AddAccount("Work")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(account.CodexHome, "sessions")); err != nil {
+		t.Fatal(err)
+	}
+	rolloutRelative := filepath.Join("2026", "08", "29", "rollout-thread.jsonl")
+	isolatedRollout := filepath.Join(account.CodexHome, "sessions", rolloutRelative)
+	if err := os.MkdirAll(filepath.Dir(isolatedRollout), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(isolatedRollout, []byte("rollout\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Open(muxRoot, primaryHome); err != nil {
+		t.Fatal(err)
+	}
+	primaryRollout := filepath.Join(primaryHome, "sessions", rolloutRelative)
+	if data, err := os.ReadFile(primaryRollout); err != nil || string(data) != "rollout\n" {
+		t.Fatalf("rollout was not made visible to the primary app: data=%q err=%v", data, err)
+	}
+	info, err := os.Lstat(filepath.Join(account.CodexHome, "sessions"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("isolated sessions should point at the shared primary store: mode=%v", info.Mode())
+	}
+}

--- a/scripts/patch_app.py
+++ b/scripts/patch_app.py
@@ -11,6 +11,7 @@ import plistlib
 import re
 import secrets
 import shutil
+import sqlite3
 import stat
 import subprocess
 import sys
@@ -50,9 +51,16 @@ TESTED_SOURCE_BUILDS = {
         "26.803.61601",
         "6396",
     ): "d5a44ed9e2f1db5f81dbbe85408aed256f3203c5b16f00817bb9d7cd941343cf",
+    (
+        "26.825.32147",
+        "7303",
+    ): "0462b03e878f0e78b223b849ee14cbba0de043f2c16acebee163cb95daa622ef",
 }
+NATIVE_7303_RENDERER_HASHES = frozenset(
+    {"0462b03e878f0e78b223b849ee14cbba0de043f2c16acebee163cb95daa622ef"}
+)
 EXPECTED_CUA_IDENTIFIER_REPLACEMENTS = 49
-EXPECTED_ASAR_CUA_IDENTIFIER_REPLACEMENTS = 17
+EXPECTED_ASAR_CUA_IDENTIFIER_REPLACEMENTS = frozenset({16, 17})
 
 
 def parse_args() -> argparse.Namespace:
@@ -83,8 +91,13 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def run(command: list[str], *, cwd: Path | None = None) -> None:
-    subprocess.run(command, cwd=cwd, check=True)
+def run(
+    command: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> None:
+    subprocess.run(command, cwd=cwd, env=env, check=True)
 
 
 def output(command: list[str]) -> str:
@@ -384,10 +397,13 @@ def patch_asar_computer_use_identity(extracted: Path) -> None:
                 OPENAI_COMPUTER_USE_BUNDLE_IDENTIFIER,
                 COMPUTER_USE_BUNDLE_IDENTIFIER,
             )
-    if replacements != EXPECTED_ASAR_CUA_IDENTIFIER_REPLACEMENTS:
+    if replacements not in EXPECTED_ASAR_CUA_IDENTIFIER_REPLACEMENTS:
+        expected = " or ".join(
+            str(count) for count in sorted(EXPECTED_ASAR_CUA_IDENTIFIER_REPLACEMENTS)
+        )
         raise RuntimeError(
             "expected "
-            f"{EXPECTED_ASAR_CUA_IDENTIFIER_REPLACEMENTS} Computer Use references "
+            f"{expected} Computer Use references "
             f"in app.asar, found {replacements}"
         )
 
@@ -415,6 +431,7 @@ def sign_native_code_tree(root: Path, identity: str) -> None:
 
 TEAM_SCOPED_ENTITLEMENTS = (
     "com.apple.application-identifier",
+    "com.apple.developer.aps-environment",
     "com.apple.developer.team-identifier",
     "com.apple.security.application-groups",
     "keychain-access-groups",
@@ -658,8 +675,89 @@ def load_or_create_token() -> str:
     return token
 
 
+def migrate_legacy_thread_indexes() -> int:
+    """Import pre-shared account thread rows into the primary Codex index."""
+    primary = Path.home() / ".codex" / "state_5.sqlite"
+    legacy_databases = sorted(
+        (DEFAULT_STATE_ROOT / "accounts").glob("*/codex-home/state_5.sqlite")
+    )
+    if not primary.is_file() or not legacy_databases:
+        return 0
+
+    connection = sqlite3.connect(str(primary), timeout=30)
+    pending = 0
+    try:
+        for index, database in enumerate(legacy_databases):
+            alias = f"legacy{index}"
+            connection.execute(f"ATTACH DATABASE ? AS {alias}", (str(database),))
+            pending += connection.execute(
+                f"SELECT count(*) FROM {alias}.threads AS legacy "
+                "WHERE NOT EXISTS (SELECT 1 FROM main.threads WHERE id = legacy.id)"
+            ).fetchone()[0]
+            connection.execute(f"DETACH DATABASE {alias}")
+        if pending == 0:
+            return 0
+
+        backup_root = DEFAULT_STATE_ROOT / "thread-index-backups"
+        backup_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        backup_root.chmod(0o700)
+        backup = backup_root / f"state_5-{time.strftime('%Y%m%d-%H%M%S')}.sqlite"
+        backup_connection = sqlite3.connect(str(backup))
+        connection.backup(backup_connection)
+        backup_connection.close()
+        backup.chmod(0o600)
+
+        primary_columns = [
+            row[1] for row in connection.execute("PRAGMA main.table_info(threads)")
+        ]
+        imported = 0
+        for index, database in enumerate(legacy_databases):
+            alias = f"legacy{index}"
+            connection.execute(f"ATTACH DATABASE ? AS {alias}", (str(database),))
+            legacy_columns = {
+                row[1]
+                for row in connection.execute(f"PRAGMA {alias}.table_info(threads)")
+            }
+            columns = [
+                column
+                for column in primary_columns
+                if column in legacy_columns
+                and column not in {"thread_section_id", "project_id"}
+            ]
+            quoted = ",".join(f'"{column}"' for column in columns)
+            source_sessions = str(database.parent / "sessions") + os.sep
+            primary_sessions = str(Path.home() / ".codex" / "sessions") + os.sep
+            select = []
+            parameters: list[object] = []
+            for column in columns:
+                if column == "rollout_path":
+                    select.append(
+                        "CASE WHEN rollout_path LIKE ? THEN ? || "
+                        "substr(rollout_path, ?) ELSE rollout_path END"
+                    )
+                    parameters.extend(
+                        (source_sessions + "%", primary_sessions, len(source_sessions) + 1)
+                    )
+                else:
+                    select.append(f'"{column}"')
+            cursor = connection.execute(
+                f"INSERT OR IGNORE INTO main.threads ({quoted}) "
+                f"SELECT {','.join(select)} FROM {alias}.threads",
+                parameters,
+            )
+            imported += max(0, cursor.rowcount)
+            connection.commit()
+            connection.execute(f"DETACH DATABASE {alias}")
+        print(f"Imported {imported} legacy chat indexes; backup saved to {backup}")
+        return imported
+    finally:
+        connection.close()
+
+
 def build_proxy(destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
+    build_environment = os.environ.copy()
+    build_environment.update({"GOARCH": "arm64", "GOOS": "darwin"})
     run(
         [
             "go",
@@ -671,6 +769,7 @@ def build_proxy(destination: Path) -> None:
             "./cmd/codex-mux",
         ],
         cwd=PROJECT_ROOT,
+        env=build_environment,
     )
     destination.chmod(destination.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
@@ -682,6 +781,8 @@ def install_launcher(app: Path) -> None:
         [
             "xcrun",
             "clang",
+            "-arch",
+            "arm64",
             "-Os",
             "-Wall",
             "-Wextra",
@@ -995,6 +1096,81 @@ def patch_renderer(extracted: Path, token: str) -> None:
     thread_bundle_path.write_text(thread_bundle, encoding="utf-8")
 
 
+def patch_renderer_7303(extracted: Path, token: str) -> None:
+    """Restore the native account, usage, and thread controls for build 7303."""
+    webview = extracted / "webview"
+    index_path = webview / "index.html"
+    index = index_path.read_text(encoding="utf-8")
+    anchor = "connect-src &#39;self&#39;"
+    if index.count(anchor) != 1:
+        raise RuntimeError("could not find ChatGPT renderer CSP connect-src")
+    index_path.write_text(
+        index.replace(anchor, f"{anchor} http://127.0.0.1:{CONTROL_PORT}", 1),
+        encoding="utf-8",
+    )
+
+    bundles = list((webview / "assets").glob("app-initial-*.js"))
+    if len(bundles) != 1:
+        raise RuntimeError(f"expected one ChatGPT initial renderer bundle, found {len(bundles)}")
+    bundle_path = bundles[0]
+    bundle = bundle_path.read_text(encoding="utf-8")
+    component = (PROJECT_ROOT / "ui" / "account-menu.js").read_text(encoding="utf-8")
+    component = component.replace("__CODEX_MUX_CONTROL_PORT__", str(CONTROL_PORT))
+    component = component.replace("__CODEX_MUX_CONTROL_TOKEN__", token)
+    for old, new in (("e7", "l8"), ("kXc", "Lwc"), ("_H", "sz"), ("CH", "pz"), ("BW", "XL"), ("QLs", "two"), ("S2", "CodexMuxPlusIcon")):
+        component = re.sub(rf"\b{re.escape(old)}\b", new, component)
+    component = component.replace("const modalScope = Lo(Q);", "const modalScope = A_($);")
+    component = component.replace("const resolvedImageUrl = jLa(imageUrl || null);", "const resolvedImageUrl = imageUrl || null;")
+    if bundle.count("function CodexMuxAccountMenu("):
+        raise RuntimeError("source app already contains the Codex multiplexer menu")
+    anchor = "function Awc(e){let t=(0,Iwc.c)(3)"
+    if bundle.count(anchor) != 1:
+        raise RuntimeError("could not find build-7303 native profile component")
+    bundle = bundle.replace(anchor, component + "\n" + anchor, 1)
+    replacements = {
+        "usageItems:Ct": "usageItems:(0,l8.jsx)(CodexMuxAccountMenu,{})",
+        "triggerButton:Dt,onOpenChange:c,children:[N,null]": "triggerButton:Dt,onOpenChange:CodexMuxProfileMenuOpenChange(c),children:[N,null]",
+        "function two(e){": "function two(e){CodexMuxUseResetAccountState();",
+        "let y=v;if(g!=null){": "let y=window.__codexMuxSelectedUsageWindows??v;if(g!=null){",
+        "children:[xe,Se]": "children:[xe,Se,window.__codexMuxResetAccountSelector??null]",
+    }
+    for old, new in replacements.items():
+        if bundle.count(old) != 1:
+            raise RuntimeError(f"could not find build-7303 native anchor: {old}")
+        bundle = bundle.replace(old, new, 1)
+    query = "function odi(){let e=(0,dR.c)(1),t;return e[0]===Symbol.for(`react.memo_cache_sentinel`)?(t={queryKey:[`rate-limit-reset-credits`],queryFn:sdi,refetchInterval:bx.ONE_MINUTE,staleTime:bx.FIVE_SECONDS},e[0]=t):t=e[0],Tx(t)}"
+    if bundle.count(query) != 1:
+        raise RuntimeError("could not find build-7303 reset-credit query")
+    bundle = bundle.replace(query, "function odi(){let e=window.__codexMuxResetAccountId;return Tx({queryKey:[`rate-limit-reset-credits`,e??`primary`],queryFn:e?()=>codexMuxRateLimitResets(e):sdi,refetchInterval:bx.ONE_MINUTE,staleTime:bx.FIVE_SECONDS})}", 1)
+    mutation = "function cdi(){let e=(0,dR.c)(3),t=Sx(),n=bD(),r;return e[0]!==n||e[1]!==t?(r={mutationFn:ldi,onSuccess:(e,r)=>{let{creditId:i}=r,a=e.code;if(a===`reset`||a===`already_redeemed`){let n=e.code===`reset`?e.credit?.id??i:i;t.setQueryData([`rate-limit-reset-credits`],e=>Mui(e,a,n))}Promise.all([n([`rate-limit-status`]),n([`rate-limit-reset-credits`])])}},e[0]=n,e[1]=t,e[2]=r):r=e[2],Dx(r)}"
+    if bundle.count(mutation) != 1:
+        raise RuntimeError("could not find build-7303 reset-credit mutation")
+    bundle = bundle.replace(mutation, "function cdi(){let e=Sx(),t=bD(),n=window.__codexMuxResetAccountId,r=[`rate-limit-reset-credits`,n??`primary`];return Dx({mutationFn:n?i=>codexMuxConsumeRateLimitReset(n,i):ldi,onSuccess:(n,i)=>{let{creditId:a}=i,o=n.code;if(o===`reset`||o===`already_redeemed`){let t=o===`reset`?n.credit?.id??a:a;e.setQueryData(r,e=>Mui(e,o,t))}Promise.all([t([`rate-limit-status`]),t(r)])}})}", 1)
+    bundle_path.write_text(bundle, encoding="utf-8")
+
+    thread_candidates = list((webview / "assets").glob("local-conversation-thread-*.js"))
+    thread_candidates = [p for p in thread_candidates if "function oE(e){let t=(0,lE.c)(34)" in p.read_text(encoding="utf-8")]
+    if len(thread_candidates) != 1:
+        raise RuntimeError(f"expected one build-7303 thread bundle, found {len(thread_candidates)}")
+    thread_path = thread_candidates[0]
+    thread = thread_path.read_text(encoding="utf-8")
+    thread_component = (PROJECT_ROOT / "ui" / "thread-subscription.js").read_text(encoding="utf-8")
+    thread_component = thread_component.replace("__CODEX_MUX_CONTROL_PORT__", str(CONTROL_PORT)).replace("__CODEX_MUX_CONTROL_TOKEN__", token)
+    thread_component = re.sub(r"\bzE\b", "uE", thread_component)
+    thread_component = re.sub(r"\bTE\b", "CodexMuxReact", thread_component)
+    thread_component = thread_component.replace("$n(sr)", "xt(wa)").replace("K.Section", "X.Section")
+    thread_component = "const CodexMuxReact=t(Qi(),1);\n" + thread_component
+    anchor = "function oE(e){let t=(0,lE.c)(34)"
+    if thread.count(anchor) != 1:
+        raise RuntimeError("could not find build-7303 thread summary component")
+    thread = thread.replace(anchor, thread_component + "\n" + anchor, 1)
+    children = "children:[l,u,d,f,p,m,h,_,v,g,y,b,x,S,C,w]"
+    if thread.count(children) != 1:
+        raise RuntimeError("could not find build-7303 thread summary section list")
+    thread = thread.replace(children, "children:[l,u,d,f,p,(0,uE.jsx)(CodexMuxThreadSubscription,{}),m,h,_,v,g,y,b,x,S,C,w]", 1)
+    thread_path.write_text(thread, encoding="utf-8")
+
+
 def patch_desktop_profile(
     extracted: Path, installed_computer_use_app: Path
 ) -> None:
@@ -1034,7 +1210,7 @@ def patch_desktop_profile(
     # The copied app must never replace itself with an unpatched official update.
     updater_pattern = re.compile(
         r"await [A-Za-z_$][\w$]*\.initialize\(\);"
-        r"(?=try\{let\{runMainAppStartup:)"
+        r"(?=(?:try\{)?let\{runMainAppStartup:)"
     )
     bootstrap, updater_replacements = updater_pattern.subn("", bootstrap, count=1)
     if updater_replacements != 1:
@@ -1212,7 +1388,10 @@ def patch_app(
         run([str(asar), "extract", str(original_asar), str(extracted)])
         patch_asar_computer_use_identity(extracted)
         patch_desktop_profile(extracted, installed_computer_use_app)
-        patch_renderer(extracted, token)
+        if source_asar_hash in NATIVE_7303_RENDERER_HASHES:
+            patch_renderer_7303(extracted, token)
+        else:
+            patch_renderer(extracted, token)
         sign_native_code_tree(extracted, signing_identity)
         repacked_asar = temporary_path / "app.asar"
         run(
@@ -1236,10 +1415,12 @@ def patch_app(
         repacked_unpacked = temporary_path / "app.asar.unpacked"
         if not repacked_unpacked.is_dir():
             raise RuntimeError("ASAR pack did not produce its unpacked native tree")
+        installed_unpacked = resources / "app.asar.unpacked"
+        if installed_unpacked.exists():
+            shutil.rmtree(installed_unpacked)
         shutil.copytree(
             repacked_unpacked,
-            resources / "app.asar.unpacked",
-            dirs_exist_ok=True,
+            installed_unpacked,
         )
 
         bundled_codex = resources / "codex"
@@ -1323,6 +1504,7 @@ def patch_app(
             ]
         )
     retire_stale_cached_computer_use_app()
+    migrate_legacy_thread_indexes()
 
     print(destination)
     print(installed_computer_use_app)

--- a/scripts/patch_app.py
+++ b/scripts/patch_app.py
@@ -55,9 +55,16 @@ TESTED_SOURCE_BUILDS = {
         "26.825.32147",
         "7303",
     ): "0462b03e878f0e78b223b849ee14cbba0de043f2c16acebee163cb95daa622ef",
+    (
+        "26.825.41651",
+        "7345",
+    ): "c089b63abb7ca4a751072c0da434248db13c32bed9c363e1b7e5428584b0576d",
 }
-NATIVE_7303_RENDERER_HASHES = frozenset(
-    {"0462b03e878f0e78b223b849ee14cbba0de043f2c16acebee163cb95daa622ef"}
+CURRENT_NATIVE_RENDERER_HASHES = frozenset(
+    {
+        "0462b03e878f0e78b223b849ee14cbba0de043f2c16acebee163cb95daa622ef",
+        "c089b63abb7ca4a751072c0da434248db13c32bed9c363e1b7e5428584b0576d",
+    }
 )
 EXPECTED_CUA_IDENTIFIER_REPLACEMENTS = 49
 EXPECTED_ASAR_CUA_IDENTIFIER_REPLACEMENTS = frozenset({16, 17})
@@ -1096,8 +1103,8 @@ def patch_renderer(extracted: Path, token: str) -> None:
     thread_bundle_path.write_text(thread_bundle, encoding="utf-8")
 
 
-def patch_renderer_7303(extracted: Path, token: str) -> None:
-    """Restore the native account, usage, and thread controls for build 7303."""
+def patch_renderer_current(extracted: Path, token: str) -> None:
+    """Restore native account, usage, and thread controls in current builds."""
     webview = extracted / "webview"
     index_path = webview / "index.html"
     index = index_path.read_text(encoding="utf-8")
@@ -1125,7 +1132,7 @@ def patch_renderer_7303(extracted: Path, token: str) -> None:
         raise RuntimeError("source app already contains the Codex multiplexer menu")
     anchor = "function Awc(e){let t=(0,Iwc.c)(3)"
     if bundle.count(anchor) != 1:
-        raise RuntimeError("could not find build-7303 native profile component")
+        raise RuntimeError("could not find current-build native profile component")
     bundle = bundle.replace(anchor, component + "\n" + anchor, 1)
     replacements = {
         "usageItems:Ct": "usageItems:(0,l8.jsx)(CodexMuxAccountMenu,{})",
@@ -1136,22 +1143,22 @@ def patch_renderer_7303(extracted: Path, token: str) -> None:
     }
     for old, new in replacements.items():
         if bundle.count(old) != 1:
-            raise RuntimeError(f"could not find build-7303 native anchor: {old}")
+            raise RuntimeError(f"could not find current-build native anchor: {old}")
         bundle = bundle.replace(old, new, 1)
     query = "function odi(){let e=(0,dR.c)(1),t;return e[0]===Symbol.for(`react.memo_cache_sentinel`)?(t={queryKey:[`rate-limit-reset-credits`],queryFn:sdi,refetchInterval:bx.ONE_MINUTE,staleTime:bx.FIVE_SECONDS},e[0]=t):t=e[0],Tx(t)}"
     if bundle.count(query) != 1:
-        raise RuntimeError("could not find build-7303 reset-credit query")
+        raise RuntimeError("could not find current-build reset-credit query")
     bundle = bundle.replace(query, "function odi(){let e=window.__codexMuxResetAccountId;return Tx({queryKey:[`rate-limit-reset-credits`,e??`primary`],queryFn:e?()=>codexMuxRateLimitResets(e):sdi,refetchInterval:bx.ONE_MINUTE,staleTime:bx.FIVE_SECONDS})}", 1)
     mutation = "function cdi(){let e=(0,dR.c)(3),t=Sx(),n=bD(),r;return e[0]!==n||e[1]!==t?(r={mutationFn:ldi,onSuccess:(e,r)=>{let{creditId:i}=r,a=e.code;if(a===`reset`||a===`already_redeemed`){let n=e.code===`reset`?e.credit?.id??i:i;t.setQueryData([`rate-limit-reset-credits`],e=>Mui(e,a,n))}Promise.all([n([`rate-limit-status`]),n([`rate-limit-reset-credits`])])}},e[0]=n,e[1]=t,e[2]=r):r=e[2],Dx(r)}"
     if bundle.count(mutation) != 1:
-        raise RuntimeError("could not find build-7303 reset-credit mutation")
+        raise RuntimeError("could not find current-build reset-credit mutation")
     bundle = bundle.replace(mutation, "function cdi(){let e=Sx(),t=bD(),n=window.__codexMuxResetAccountId,r=[`rate-limit-reset-credits`,n??`primary`];return Dx({mutationFn:n?i=>codexMuxConsumeRateLimitReset(n,i):ldi,onSuccess:(n,i)=>{let{creditId:a}=i,o=n.code;if(o===`reset`||o===`already_redeemed`){let t=o===`reset`?n.credit?.id??a:a;e.setQueryData(r,e=>Mui(e,o,t))}Promise.all([t([`rate-limit-status`]),t(r)])}})}", 1)
     bundle_path.write_text(bundle, encoding="utf-8")
 
     thread_candidates = list((webview / "assets").glob("local-conversation-thread-*.js"))
     thread_candidates = [p for p in thread_candidates if "function oE(e){let t=(0,lE.c)(34)" in p.read_text(encoding="utf-8")]
     if len(thread_candidates) != 1:
-        raise RuntimeError(f"expected one build-7303 thread bundle, found {len(thread_candidates)}")
+        raise RuntimeError(f"expected one current-build thread bundle, found {len(thread_candidates)}")
     thread_path = thread_candidates[0]
     thread = thread_path.read_text(encoding="utf-8")
     thread_component = (PROJECT_ROOT / "ui" / "thread-subscription.js").read_text(encoding="utf-8")
@@ -1162,11 +1169,11 @@ def patch_renderer_7303(extracted: Path, token: str) -> None:
     thread_component = "const CodexMuxReact=t(Qi(),1);\n" + thread_component
     anchor = "function oE(e){let t=(0,lE.c)(34)"
     if thread.count(anchor) != 1:
-        raise RuntimeError("could not find build-7303 thread summary component")
+        raise RuntimeError("could not find current-build thread summary component")
     thread = thread.replace(anchor, thread_component + "\n" + anchor, 1)
     children = "children:[l,u,d,f,p,m,h,_,v,g,y,b,x,S,C,w]"
     if thread.count(children) != 1:
-        raise RuntimeError("could not find build-7303 thread summary section list")
+        raise RuntimeError("could not find current-build thread summary section list")
     thread = thread.replace(children, "children:[l,u,d,f,p,(0,uE.jsx)(CodexMuxThreadSubscription,{}),m,h,_,v,g,y,b,x,S,C,w]", 1)
     thread_path.write_text(thread, encoding="utf-8")
 
@@ -1388,8 +1395,8 @@ def patch_app(
         run([str(asar), "extract", str(original_asar), str(extracted)])
         patch_asar_computer_use_identity(extracted)
         patch_desktop_profile(extracted, installed_computer_use_app)
-        if source_asar_hash in NATIVE_7303_RENDERER_HASHES:
-            patch_renderer_7303(extracted, token)
+        if source_asar_hash in CURRENT_NATIVE_RENDERER_HASHES:
+            patch_renderer_current(extracted, token)
         else:
             patch_renderer(extracted, token)
         sign_native_code_tree(extracted, signing_identity)

--- a/ui/account-menu.js
+++ b/ui/account-menu.js
@@ -177,6 +177,14 @@ function CodexMuxResetAccountSelector({
           : accounts.map((account) => {
               const selected = account.id === selectedId;
               const count = resetCounts[account.id];
+              const short = codexMuxFiveHourWindow(account.rateLimits);
+              const weekly = codexMuxWeeklyWindow(account.rateLimits);
+              const remaining =
+                short == null ? null : Math.max(0, 100 - short.usedPercent);
+              const weeklyRemaining =
+                weekly == null ? null : Math.max(0, 100 - weekly.usedPercent);
+              const resetTime = codexMuxFormatResetTime(short?.resetsAt);
+              const weeklyResetTime = codexMuxFormatResetTime(weekly?.resetsAt);
               return (0, e7.jsxs)(
                 "button",
                 {
@@ -205,14 +213,28 @@ function CodexMuxResetAccountSelector({
                             ? `${account.label} · ${account.planLabel}`
                             : account.label,
                         }),
+                        (0, e7.jsxs)("span", {
+                          className: "text-xs text-token-text-tertiary",
+                          children: [
+                            remaining == null ? "5h unavailable" : `${Math.round(remaining)}% of 5h remaining`,
+                            resetTime ? ` · resets ${resetTime}` : "",
+                          ],
+                        }),
+                        (0, e7.jsxs)("span", {
+                          className: "text-xs text-token-text-tertiary",
+                          children: [
+                            weeklyRemaining == null ? "Weekly unavailable" : `${Math.round(weeklyRemaining)}% weekly remaining`,
+                            weeklyResetTime ? ` · resets ${weeklyResetTime}` : "",
+                          ],
+                        }),
                         (0, e7.jsx)("span", {
                           className: "text-xs text-token-text-tertiary",
                           children:
                             count == null
-                              ? "Resets unavailable"
+                              ? "Limit resets unavailable"
                               : count === 1
-                                ? "1 reset available"
-                                : `${count} resets available`,
+                                ? "1 manual reset available"
+                                : `${count} manual resets available`,
                         }),
                       ],
                     }),
@@ -397,8 +419,14 @@ function CodexMuxAccountMenu() {
   }
 
   for (const account of connected) {
+    const short = codexMuxFiveHourWindow(account.rateLimits);
     const weekly = codexMuxWeeklyWindow(account.rateLimits);
-    const remaining = weekly == null ? null : Math.max(0, 100 - weekly.usedPercent);
+    const remaining =
+      short == null ? null : Math.max(0, 100 - short.usedPercent);
+    const resetTime = codexMuxFormatResetTime(short?.resetsAt);
+    const weeklyRemaining =
+      weekly == null ? null : Math.max(0, 100 - weekly.usedPercent);
+    const weeklyResetTime = codexMuxFormatResetTime(weekly?.resetsAt);
     rows.push(
       (0, e7.jsx)(
         _H,
@@ -409,13 +437,35 @@ function CodexMuxAccountMenu() {
               imageUrl: account.profileImageUrl,
               label: account.label,
             }),
-          SubText: account.email
-            ? (0, e7.jsx)(CodexMuxMaskedEmail, { email: account.email })
-            : account.planType || "ChatGPT subscription",
+          SubText: (0, e7.jsxs)("span", {
+            children: [
+              account.email
+                ? (0, e7.jsx)(CodexMuxMaskedEmail, { email: account.email })
+                : account.planType || "ChatGPT subscription",
+            ],
+          }),
           className: "group",
           rightIcon: (0, e7.jsx)("span", {
-            className: "text-token-description-foreground tabular-nums",
-            children: remaining == null ? "–" : `${Math.round(remaining)}%`,
+            className: "min-w-28 text-right text-xs leading-4 text-token-description-foreground tabular-nums",
+            children: (0, e7.jsxs)("span", {
+              children: [
+                (0, e7.jsx)("span", {
+                  className: "block",
+                  children: remaining == null ? "– 5h" : `${Math.round(remaining)}% 5h`,
+                }),
+                (0, e7.jsx)("span", {
+                  className: "block text-token-text-tertiary",
+                  children: weeklyRemaining == null ? "– weekly" : `${Math.round(weeklyRemaining)}% weekly`,
+                }),
+                resetTime || weeklyResetTime
+                  ? (0, e7.jsx)("span", {
+                      className: "block max-w-36 truncate text-token-text-tertiary",
+                      title: `5h resets ${resetTime || "unknown"}; weekly resets ${weeklyResetTime || "unknown"}`,
+                      children: `5h ${resetTime || "—"} · W ${weeklyResetTime || "—"}`,
+                    })
+                  : null,
+              ],
+            }),
           }),
           children: account.planLabel
             ? `${account.label} · ${account.planLabel}`
@@ -486,6 +536,31 @@ function codexMuxWeeklyWindow(rateLimits) {
       (left.windowDurationMins || 0) - (right.windowDurationMins || 0),
   );
   return windows.at(-1) || null;
+}
+
+function codexMuxFiveHourWindow(rateLimits) {
+  const windows = [rateLimits?.primary, rateLimits?.secondary].filter(Boolean);
+  const exact = windows.find((window) => window.windowDurationMins === 300);
+  if (exact) return exact;
+  windows.sort(
+    (left, right) =>
+      (left.windowDurationMins || 0) - (right.windowDurationMins || 0),
+  );
+  return windows.length > 1 || (windows[0]?.windowDurationMins || 0) <= 300
+    ? windows[0] || null
+    : null;
+}
+
+function codexMuxFormatResetTime(resetsAt) {
+  if (resetsAt == null) return "";
+  const date = new Date(resetsAt * 1000);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }
 
 function codexMuxUsageWindows(rateLimits) {

--- a/ui/thread-subscription.js
+++ b/ui/thread-subscription.js
@@ -6,6 +6,10 @@ function CodexMuxThreadSubscription() {
   const threadId =
     route.value.routeKind === "local-thread" ? route.value.conversationId : null;
   const [account, setAccount] = TE.useState(null);
+  const [accounts, setAccounts] = TE.useState([]);
+  const [switching, setSwitching] = TE.useState(false);
+  const [error, setError] = TE.useState("");
+  const [selectorOpen, setSelectorOpen] = TE.useState(false);
 
   TE.useEffect(() => {
     let active = true;
@@ -23,8 +27,24 @@ function CodexMuxThreadSubscription() {
           { headers: { "X-Codex-Mux-Token": CODEX_MUX_THREAD_TOKEN } },
         );
         if (!response.ok) throw new Error(`Request failed (${response.status})`);
-        const body = await response.json();
-        if (active) setAccount(body.account || null);
+        const [body, accountsResponse] = await Promise.all([
+          response.json(),
+          fetch(`${CODEX_MUX_THREAD_API}/accounts`, {
+            headers: { "X-Codex-Mux-Token": CODEX_MUX_THREAD_TOKEN },
+          }).then((result) => (result.ok ? result.json() : { accounts: [] })),
+        ]);
+        if (active) {
+          setAccount(body.account || null);
+          setAccounts(
+            (accountsResponse.accounts || []).filter(
+              (candidate) =>
+                candidate.enabled &&
+                candidate.connected &&
+                candidate.authType === "chatgpt",
+            ),
+          );
+          setError("");
+        }
       } catch {
         if (active) setAccount(null);
       }
@@ -39,7 +59,8 @@ function CodexMuxThreadSubscription() {
         const payload = JSON.parse(event.data);
         if (
           payload.type === "account-updated" ||
-          (payload.type === "thread-failed-over" &&
+          ((payload.type === "thread-failed-over" ||
+            payload.type === "thread-account-changed") &&
             payload.data?.threadId === threadId)
         ) {
           refresh();
@@ -57,46 +78,165 @@ function CodexMuxThreadSubscription() {
   }, [threadId]);
 
   if (!account) return null;
+  const short = codexMuxThreadFiveHourWindow(account.rateLimits);
   const weekly = codexMuxThreadWeeklyWindow(account.rateLimits);
-  const remaining = weekly == null ? null : Math.max(0, 100 - weekly.usedPercent);
+  const remaining =
+    short == null ? null : Math.max(0, 100 - short.usedPercent);
   const depleted = remaining === 0;
   const AccountAvatar = globalThis.CodexMuxAccountAvatar;
+
+  async function switchAccount(accountId) {
+    if (!accountId || accountId === account.id || switching) return;
+    setSelectorOpen(false);
+    setSwitching(true);
+    setError("");
+    try {
+      const response = await fetch(`${CODEX_MUX_THREAD_API}/thread-account`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Codex-Mux-Token": CODEX_MUX_THREAD_TOKEN,
+        },
+        body: JSON.stringify({ threadId, accountId }),
+      });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(body.error || `Request failed (${response.status})`);
+      }
+      setAccount(body.account || null);
+    } catch (switchError) {
+      setError(switchError.message);
+    } finally {
+      setSwitching(false);
+    }
+  }
   return (0, zE.jsx)(K.Section, {
     sectionKey: "codex-mux-subscription",
     title: "Subscription",
     children: (0, zE.jsxs)("div", {
-      className: "flex min-h-9 items-center justify-between gap-3 py-1 text-sm",
+      className: "space-y-2 py-1 text-sm",
       children: [
         (0, zE.jsxs)("div", {
-          className: "flex min-w-0 items-center gap-2",
+          className: "flex min-h-9 items-center justify-between gap-3",
           children: [
-            AccountAvatar
-              ? (0, zE.jsx)(AccountAvatar, {
-                  imageUrl: account.profileImageUrl,
-                  label: account.label,
-                  className: "size-5 shrink-0",
-                })
-              : null,
-            (0, zE.jsx)("span", {
-              className: "truncate text-token-text-primary",
-              children: account.planLabel
-                ? `${account.label} · ${account.planLabel}`
-                : account.label,
+            (0, zE.jsxs)("div", {
+              className: "flex min-w-0 items-center gap-2",
+              children: [
+                AccountAvatar
+                  ? (0, zE.jsx)(AccountAvatar, {
+                      imageUrl: account.profileImageUrl,
+                      label: account.label,
+                      className: "size-5 shrink-0",
+                    })
+                  : null,
+                (0, zE.jsx)("span", {
+                  className: "truncate text-token-text-primary",
+                  children: account.planLabel
+                    ? `${account.label} · ${account.planLabel}`
+                    : account.label,
+                }),
+              ],
+            }),
+            (0, zE.jsxs)("span", {
+              className: "shrink-0 text-right tabular-nums text-token-description-foreground",
+              children: [
+                (0, zE.jsx)("span", {
+                  className: "block",
+                  children: remaining == null ? "5h unavailable" : depleted ? "5h depleted" : `${Math.round(remaining)}% 5h`,
+                }),
+                (0, zE.jsx)("span", {
+                  className: "block text-xs",
+                  children: weekly == null ? "weekly unavailable" : `${Math.round(Math.max(0, 100 - weekly.usedPercent))}% weekly`,
+                }),
+              ],
             }),
           ],
         }),
-        (0, zE.jsx)("span", {
-          className: "shrink-0 tabular-nums text-token-description-foreground",
-          children:
-            remaining == null
-              ? "Usage unavailable"
-              : depleted
-                ? "Depleted"
-                : `${Math.round(remaining)}% remaining`,
-        }),
+        accounts.length > 1
+          ? (0, zE.jsxs)("div", {
+              className: "relative",
+              children: [
+                (0, zE.jsxs)("button", {
+                  type: "button",
+                  className: "flex w-full items-center justify-between rounded-xl border border-token-border bg-token-bg-primary px-3 py-2 text-left text-sm text-token-text-primary shadow-xs transition-colors hover:bg-token-foreground/5 focus:border-token-text-secondary",
+                  "aria-expanded": selectorOpen,
+                  "aria-haspopup": "listbox",
+                  onClick: () => setSelectorOpen((open) => !open),
+                  children: [
+                    (0, zE.jsx)("span", {
+                      className: "truncate",
+                      children: `${account.label} · ${remaining == null ? "5h unavailable" : `${Math.round(remaining)}% 5h`} · ${weekly == null ? "weekly unavailable" : `${Math.round(Math.max(0, 100 - weekly.usedPercent))}% weekly`}`,
+                    }),
+                    (0, zE.jsx)("span", {
+                      className: "ml-2 text-token-text-secondary",
+                      children: selectorOpen ? "⌃" : "⌄",
+                    }),
+                  ],
+                }),
+                selectorOpen
+                  ? (0, zE.jsx)("div", {
+                      role: "listbox",
+                      className: "mt-1 overflow-hidden rounded-xl border border-token-border bg-token-bg-primary p-1 shadow-lg",
+                      children: accounts.map((candidate) => {
+                        const candidateShort = codexMuxThreadFiveHourWindow(candidate.rateLimits);
+                        const candidateRemaining = candidateShort == null ? null : Math.max(0, 100 - candidateShort.usedPercent);
+                        const candidateWeekly = codexMuxThreadWeeklyWindow(candidate.rateLimits);
+                        const candidateWeeklyRemaining = candidateWeekly == null ? null : Math.max(0, 100 - candidateWeekly.usedPercent);
+                        const candidateReset = codexMuxThreadFormatResetTime(candidateShort?.resetsAt);
+                        const candidateWeeklyReset = codexMuxThreadFormatResetTime(candidateWeekly?.resetsAt);
+                        const depletedCandidate = candidateRemaining === 0;
+                        return (0, zE.jsxs)("button", {
+                          type: "button",
+                          role: "option",
+                          "aria-selected": candidate.id === account.id,
+                          disabled: depletedCandidate || switching,
+                          onClick: () => switchAccount(candidate.id),
+                          className: "flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-token-foreground/5 disabled:cursor-not-allowed disabled:opacity-50",
+                          children: [
+                            (0, zE.jsxs)("span", {
+                              className: "min-w-0",
+                              children: [
+                                (0, zE.jsx)("span", { className: "block truncate", children: `${candidate.label} · ${candidateRemaining == null ? "5h unavailable" : `${Math.round(candidateRemaining)}% 5h`} · ${candidateWeeklyRemaining == null ? "weekly unavailable" : `${Math.round(candidateWeeklyRemaining)}% weekly`}` }),
+                                (0, zE.jsx)("span", { className: "block truncate text-xs text-token-text-tertiary", children: `5h resets ${candidateReset || "—"} · weekly resets ${candidateWeeklyReset || "—"}` }),
+                              ],
+                            }),
+                            candidate.id === account.id ? (0, zE.jsx)("span", { className: "text-lg text-token-text-secondary", children: "✓" }) : null,
+                          ],
+                        }, candidate.id);
+                      }),
+                    })
+                  : null,
+              ],
+            })
+          : null,
+        switching
+          ? (0, zE.jsx)("div", {
+              className: "text-xs text-token-text-tertiary",
+              children: "Moving chat history…",
+            })
+          : null,
+        error
+          ? (0, zE.jsx)("div", {
+              className: "text-xs text-red-500",
+              children: error,
+            })
+          : null,
       ],
     }),
   });
+}
+
+function codexMuxThreadFiveHourWindow(rateLimits) {
+  const windows = [rateLimits?.primary, rateLimits?.secondary].filter(Boolean);
+  const exact = windows.find((window) => window.windowDurationMins === 300);
+  if (exact) return exact;
+  windows.sort(
+    (left, right) =>
+      (left.windowDurationMins || 0) - (right.windowDurationMins || 0),
+  );
+  return windows.length > 1 || (windows[0]?.windowDurationMins || 0) <= 300
+    ? windows[0] || null
+    : null;
 }
 
 function codexMuxThreadWeeklyWindow(rateLimits) {
@@ -106,4 +246,16 @@ function codexMuxThreadWeeklyWindow(rateLimits) {
       (left.windowDurationMins || 0) - (right.windowDurationMins || 0),
   );
   return windows.at(-1) || null;
+}
+
+function codexMuxThreadFormatResetTime(resetsAt) {
+  if (resetsAt == null) return "";
+  const date = new Date(resetsAt * 1000);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }


### PR DESCRIPTION
## Summary

- share rollout storage and the SQLite thread index while keeping per-account credentials isolated
- resume idle chats on a selected subscription and automatically continue terminal usage-limit failures on another account
- show per-account 5-hour and weekly usage, reset times, and a native-style per-chat account selector
- add fail-closed renderer support for ChatGPT desktop 26.825.32147 (build 7303) while preserving build 6396 support
- migrate legacy isolated thread indexes transactionally after creating a private backup

## Security and migration notes

- OAuth files remain inside each account-specific `CODEX_HOME`; only conversation rollouts and the thread index are shared.
- Manual switching requires a connected, enabled ChatGPT account with available short- and weekly-window capacity, and refuses to move an active turn.
- The control API remains loopback-only and token-authenticated.
- Existing isolated rollout directories are merged with collision checks, preserved as timestamped backups, and replaced by links to the primary rollout store.
- Legacy SQLite rows are imported with `INSERT OR IGNORE`; the primary database is backed up before any import.
- No official app bundle, extracted renderer, credentials, or account data is included.

## Validation

- `npm run check`
- `npm run release:check`
- build 7303 renderer patch dry-run against the recorded official ASAR
- locally installed and exercised with two connected subscriptions, including shared chat discovery, manual switching, usage display, and automatic failover

## Compatibility

Adds tested support for ChatGPT desktop `26.825.32147` / build `7303` / ASAR `0462b03e878f0e78b223b849ee14cbba0de043f2c16acebee163cb95daa622ef` on Apple silicon.