### PR TITLE
Support build 7746 and stabilize subscription routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ this project uses [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Compatibility with official ChatGPT `26.810.52044` (build `6662`).
 - One-command installer with safe source updates, prerequisite checks, signed
   rebuilds, recoverable upgrades, and automatic launch.
 - Reset-aware routing that prioritizes weekly quota at risk of expiring and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ this project uses [Semantic Versioning](https://semver.org/).
 - Native usage surfaces (limit banner, sidebar usage alert, reset prompts)
   now reflect pooled usage, so a depleted Primary account no longer triggers
   them while another connected subscription still has weekly capacity.
+### Changed
+
+- The account menu, Usage sheet, and Plugins picker open with the last known
+  subscriptions and usage and refresh in place instead of showing a connecting
+  state on every open.
 
 ## [0.1.0] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ this project uses [Semantic Versioning](https://semver.org/).
 - Reset-aware routing that prioritizes weekly quota at risk of expiring and
   gives a bounded boost to subscriptions with banked usage resets.
 
+### Fixed
+
+- Profile menus now dismiss normally on outside clicks and Escape after an
+  additional subscription sign-in.
+
 ## [0.1.0] - 2026-08-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ this project uses [Semantic Versioning](https://semver.org/).
 
 - Profile menus now dismiss normally on outside clicks and Escape after an
   additional subscription sign-in.
+- Native usage surfaces (limit banner, sidebar usage alert, reset prompts)
+  now reflect pooled usage, so a depleted Primary account no longer triggers
+  them while another connected subscription still has weekly capacity.
 
 ## [0.1.0] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ this project uses [Semantic Versioning](https://semver.org/).
 - The account menu, Usage sheet, and Plugins picker open with the last known
   subscriptions and usage and refresh in place instead of showing a connecting
   state on every open.
+- The copied app can no longer start Sparkle through the renderer's update
+  gate or the Check for Updates menu item, so it does not offer to replace
+  itself with an unpatched official build.
 
 ## [0.1.0] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ this project uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Slow profile-photo requests no longer block the first subscription list from
+  showing connected accounts.
 - Profile menus now dismiss normally on outside clicks and Escape after an
   additional subscription sign-in.
 - Native usage surfaces (limit banner, sidebar usage alert, reset prompts)

--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ Codex Subscription Router currently targets:
 | Component | Supported value |
 | --- | --- |
 | Platform | macOS on Apple silicon |
-| Official ChatGPT version | `26.803.61601` |
-| Official bundle build | `6396` |
+| Official ChatGPT versions | `26.803.61601` (build `6396`), `26.810.52044` (build `6662`) |
 | Go | 1.26 or newer |
 | Node.js | 22.12 or newer |
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ starts another sign-in.
 | --- | --- |
 | New chat | Assigned by quota-at-risk, banked resets, and short-window pressure |
 | Follow-up | Sent to the thread's persisted account owner |
+| Primary depleted | Native usage surfaces show pooled usage; limit banners wait for the whole pool |
 | Owner depleted | Continued through another account with capacity |
 | Every account depleted | Combined quota alert with the next known reset |
 | Account disabled | Excluded from routing and pooled usable quota |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Codex Subscription Router currently targets:
 | Component | Supported value |
 | --- | --- |
 | Platform | macOS on Apple silicon |
-| Official ChatGPT versions | `26.803.61601` (build `6396`), `26.810.52044` (build `6662`) |
+| Official ChatGPT versions | `26.803.61601` (build `6396`), `26.810.52044` (build `6662`), `26.901.22334` (build `7746`) |
 | Go | 1.26 or newer |
 | Node.js | 22.12 or newer |
 

--- a/cmd/codex-mux/main.go
+++ b/cmd/codex-mux/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -109,18 +110,47 @@ func run() error {
 		}()
 	}
 
-	scanner := bufio.NewScanner(os.Stdin)
-	scanner.Buffer(make([]byte, 64*1024), 64*1024*1024)
-	for scanner.Scan() {
-		message, parseErr := protocol.Parse(scanner.Bytes())
-		if parseErr != nil {
-			fmt.Fprintf(os.Stderr, "codex-mux: ignore invalid client JSON: %v\n", parseErr)
-			continue
+	return serveClientMessages(
+		ctx,
+		os.Stdin,
+		multiplexer.HandleClient,
+		os.Stderr,
+	)
+}
+
+func serveClientMessages(
+	ctx context.Context,
+	input io.Reader,
+	handle func(protocol.Message),
+	diagnostics io.Writer,
+) error {
+	finished := make(chan error, 1)
+	go func() {
+		scanner := bufio.NewScanner(input)
+		scanner.Buffer(make([]byte, 64*1024), 64*1024*1024)
+		for scanner.Scan() {
+			select {
+			case <-ctx.Done():
+				finished <- nil
+				return
+			default:
+			}
+			message, parseErr := protocol.Parse(scanner.Bytes())
+			if parseErr != nil {
+				fmt.Fprintf(diagnostics, "codex-mux: ignore invalid client JSON: %v\n", parseErr)
+				continue
+			}
+			handle(message)
 		}
-		multiplexer.HandleClient(message)
+		finished <- scanner.Err()
+	}()
+
+	select {
+	case err := <-finished:
+		return err
+	case <-ctx.Done():
+		return nil
 	}
-	cancel()
-	return scanner.Err()
 }
 
 func resolveRealExecutable() (string, error) {

--- a/cmd/codex-mux/main_test.go
+++ b/cmd/codex-mux/main_test.go
@@ -1,6 +1,13 @@
 package main
 
-import "testing"
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/b-nnett/codex-subscription-router/internal/protocol"
+)
 
 func TestInteractiveAppServerDetection(t *testing.T) {
 	tests := []struct {
@@ -28,5 +35,34 @@ func TestValidateControlToken(t *testing.T) {
 		if _, err := validateControlToken(invalid); err == nil {
 			t.Fatalf("validateControlToken(%q) unexpectedly succeeded", invalid)
 		}
+	}
+}
+
+func TestServeClientMessagesReturnsWhenContextIsCanceled(t *testing.T) {
+	reader, writer := io.Pipe()
+	t.Cleanup(func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		result <- serveClientMessages(
+			ctx,
+			reader,
+			func(protocol.Message) {},
+			io.Discard,
+		)
+	}()
+
+	cancel()
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("canceled client reader returned an error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("client reader stayed blocked on stdin after cancellation")
 	}
 }

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -6,11 +6,13 @@ stops instead of applying a partial patch.
 
 ## Release 0.1.0
 
+| Official ChatGPT version | Official bundle build | `app.asar` SHA-256 |
+| --- | --- | --- |
+| `26.803.61601` | `6396` | `d5a44ed9e2f1db5f81dbbe85408aed256f3203c5b16f00817bb9d7cd941343cf` |
+| `26.810.52044` | `6662` | `6e7e8791b8bf69a586ff994721fff518af391d9efdc66cd2e620dd2a4aedc90f` |
+
 | Component | Tested value |
 | --- | --- |
-| Official ChatGPT version | `26.803.61601` |
-| Official bundle build | `6396` |
-| `app.asar` SHA-256 | `d5a44ed9e2f1db5f81dbbe85408aed256f3203c5b16f00817bb9d7cd941343cf` |
 | Architecture | Apple silicon (`arm64`) |
 
 A different official version may work when all anchors remain identical, but

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -10,6 +10,7 @@ stops instead of applying a partial patch.
 | --- | --- | --- |
 | `26.803.61601` | `6396` | `d5a44ed9e2f1db5f81dbbe85408aed256f3203c5b16f00817bb9d7cd941343cf` |
 | `26.810.52044` | `6662` | `6e7e8791b8bf69a586ff994721fff518af391d9efdc66cd2e620dd2a4aedc90f` |
+| `26.901.22334` | `7746` | `405f0e1600fc63851abe4c763ec0546f56c32da312c2c2745e2b997c579ce0d0` |
 
 | Component | Tested value |
 | --- | --- |

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -21,6 +21,8 @@ type Server struct {
 	http    *http.Server
 }
 
+const accountListTimeout = 5 * time.Second
+
 func New(address, token string, multiplexer *mux.Multiplexer, uiTests bool) *Server {
 	server := &Server{token: token, mux: multiplexer, uiTests: uiTests}
 	router := http.NewServeMux()
@@ -161,7 +163,7 @@ func (s *Server) accounts(response http.ResponseWriter, request *http.Request) {
 	}
 	switch request.Method {
 	case http.MethodGet:
-		ctx, cancel := context.WithTimeout(request.Context(), 20*time.Second)
+		ctx, cancel := context.WithTimeout(request.Context(), accountListTimeout)
 		defer cancel()
 		writeJSON(response, http.StatusOK, map[string]any{"accounts": s.mux.Accounts(ctx)})
 	case http.MethodPost:

--- a/internal/mux/accounts.go
+++ b/internal/mux/accounts.go
@@ -191,7 +191,7 @@ func (m *Multiplexer) accountSnapshotWithProfile(ctx context.Context, accountID 
 		snapshot.PlanType = details.PlanType
 		snapshot.PlanLabel = planLabel(details.PlanType)
 		if includeProfile {
-			snapshot.ProfileImageURL = m.profileImageURL(ctx, account)
+			snapshot.ProfileImageURL = m.profileImageURLCachedOrSchedule(account)
 		}
 		if details.Type == "chatgpt" {
 			rateResponse, rateErr := child.Request(ctx, "account/rateLimits/read", nil)

--- a/internal/mux/accounts.go
+++ b/internal/mux/accounts.go
@@ -67,34 +67,53 @@ func (m *Multiplexer) Accounts(ctx context.Context) []AccountSnapshot {
 
 func (m *Multiplexer) accountSnapshots(ctx context.Context, includeProfile bool) []AccountSnapshot {
 	accounts := m.store.Accounts()
-	results := make(chan AccountSnapshot, len(accounts))
-	for _, account := range accounts {
-		go func(account state.Account) {
+	threadCounts := m.store.ThreadCounts()
+	sort.SliceStable(accounts, func(i, j int) bool {
+		if accounts[i].Controller != accounts[j].Controller {
+			return accounts[i].Controller
+		}
+		return accounts[i].CreatedAt < accounts[j].CreatedAt
+	})
+
+	type snapshotResult struct {
+		index    int
+		snapshot AccountSnapshot
+	}
+	results := make(chan snapshotResult, len(accounts))
+	snapshots := make([]AccountSnapshot, len(accounts))
+	completed := make([]bool, len(accounts))
+	for index, account := range accounts {
+		snapshots[index] = AccountSnapshot{
+			ID: account.ID, Label: account.Label, Enabled: account.Enabled,
+			Controller: account.Controller, CreatedAt: account.CreatedAt,
+			ThreadCount: threadCounts[account.ID],
+		}
+		go func(index int, account state.Account) {
 			snapshot, err := m.accountSnapshotWithProfile(ctx, account.ID, includeProfile)
 			if err != nil {
 				snapshot = AccountSnapshot{
 					ID: account.ID, Label: account.Label, Enabled: account.Enabled,
-					Controller: account.Controller, CreatedAt: account.CreatedAt, Error: err.Error(),
+					Controller: account.Controller, CreatedAt: account.CreatedAt,
+					ThreadCount: threadCounts[account.ID], Error: err.Error(),
 				}
 			}
-			results <- snapshot
-		}(account)
+			results <- snapshotResult{index: index, snapshot: snapshot}
+		}(index, account)
 	}
-	snapshots := make([]AccountSnapshot, 0, len(accounts))
 	for range accounts {
 		select {
-		case snapshot := <-results:
-			snapshots = append(snapshots, snapshot)
+		case result := <-results:
+			snapshots[result.index] = result.snapshot
+			completed[result.index] = true
 		case <-ctx.Done():
+			for index := range snapshots {
+				if !completed[index] {
+					snapshots[index].Error = ctx.Err().Error()
+				}
+			}
 			return snapshots
 		}
 	}
-	sort.SliceStable(snapshots, func(i, j int) bool {
-		if snapshots[i].Controller != snapshots[j].Controller {
-			return snapshots[i].Controller
-		}
-		return snapshots[i].CreatedAt < snapshots[j].CreatedAt
-	})
 	return snapshots
 }
 

--- a/internal/mux/accounts_test.go
+++ b/internal/mux/accounts_test.go
@@ -1,9 +1,23 @@
 package mux
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/b-nnett/codex-subscription-router/internal/state"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
 
 func TestPlanLabel(t *testing.T) {
 	tests := map[string]string{
@@ -22,6 +36,64 @@ func TestPlanLabel(t *testing.T) {
 			t.Errorf("planLabel(%q) = %q, want %q", planType, got, want)
 		}
 	}
+}
+
+func TestProfileImageLookupDoesNotBlockAccountSnapshot(t *testing.T) {
+	requestStarted := make(chan struct{}, 1)
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requestStarted <- struct{}{}
+		time.Sleep(150 * time.Millisecond)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"profile":{"profile_picture_url":"https://example.com/avatar.png"}}`)),
+			Request:    request,
+		}, nil
+	})}
+
+	codexHome := t.TempDir()
+	auth, err := json.Marshal(map[string]any{
+		"tokens": map[string]string{"access_token": "test-token", "account_id": "test-account"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(codexHome, "auth.json"), auth, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	multiplexer := &Multiplexer{
+		profileClient:   client,
+		profileEndpoint: "https://chatgpt.test/profile",
+		profileCache:    make(map[string]profileCacheEntry),
+		profilePending:  make(map[string]bool),
+		now:             time.Now,
+	}
+	account := state.Account{ID: "primary", CodexHome: codexHome}
+
+	startedAt := time.Now()
+	if imageURL := multiplexer.profileImageURLCachedOrSchedule(account); imageURL != "" {
+		t.Fatalf("first uncached lookup should return immediately, got %q", imageURL)
+	}
+	if elapsed := time.Since(startedAt); elapsed > 50*time.Millisecond {
+		t.Fatalf("uncached profile lookup blocked the account snapshot for %s", elapsed)
+	}
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("background profile request did not start")
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if imageURL := multiplexer.profileImageURLCachedOrSchedule(account); imageURL != "" {
+			if imageURL != "https://example.com/avatar.png" {
+				t.Fatalf("unexpected cached image URL %q", imageURL)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("background profile lookup did not populate the cache")
 }
 
 func TestLongestAndShortestWindowUsesQuotaDuration(t *testing.T) {

--- a/internal/mux/accounts_test.go
+++ b/internal/mux/accounts_test.go
@@ -1,7 +1,10 @@
 package mux
 
 import (
+	"bufio"
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -17,6 +20,141 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
 	return function(request)
+}
+
+func TestAccountSnapshotsPreserveUnavailableAccountsAfterDeadline(t *testing.T) {
+	multiplexer, accounts, responseDir := newAccountSnapshotTestMultiplexer(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	snapshotResult := make(chan []AccountSnapshot, 1)
+	go func() { snapshotResult <- multiplexer.Accounts(ctx) }()
+	waitForAccountSnapshotResponses(t, responseDir, accounts[:2])
+	cancel()
+
+	startedAt := time.Now()
+	snapshots := <-snapshotResult
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("account list did not return promptly after its deadline: %s", elapsed)
+	}
+	if len(snapshots) != len(accounts) {
+		t.Fatalf("account list lost persisted accounts after a child blocked: got %d, want %d (%#v)", len(snapshots), len(accounts), snapshots)
+	}
+	for index, account := range accounts {
+		if snapshots[index].ID != account.ID || snapshots[index].Label != account.Label ||
+			snapshots[index].Enabled != account.Enabled || snapshots[index].Controller != account.Controller ||
+			snapshots[index].CreatedAt != account.CreatedAt {
+			t.Fatalf("persisted account was not preserved at %d: got %#v, want %#v", index, snapshots[index], account)
+		}
+	}
+
+	for _, responsive := range snapshots[:2] {
+		if responsive.Error != "" || !responsive.Connected || responsive.AuthType != "api" {
+			t.Fatalf("live child response did not replace its fallback: %#v", responsive)
+		}
+	}
+	blocked := snapshots[len(snapshots)-1]
+	if blocked.ID != accounts[len(accounts)-1].ID || blocked.Error != context.Canceled.Error() {
+		t.Fatalf("blocked account did not retain an unavailable fallback: %#v", blocked)
+	}
+	if blocked.Connected {
+		t.Fatalf("unavailable account must not be treated as connected or routeable: %#v", blocked)
+	}
+}
+
+func newAccountSnapshotTestMultiplexer(t *testing.T) (*Multiplexer, []state.Account, string) {
+	t.Helper()
+	root := t.TempDir()
+	primaryHome := filepath.Join(root, "primary")
+	if err := os.MkdirAll(primaryHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	store, err := state.Open(filepath.Join(root, "mux"), primaryHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AddAccount("Responsive"); err != nil {
+		t.Fatal(err)
+	}
+	blockedAccount, err := store.AddAccount("Blocked")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(blockedAccount.CodexHome, "block-account-read"), []byte("1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	responseDir := filepath.Join(root, "account-read-responses")
+	if err := os.MkdirAll(responseDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	multiplexer, err := New(Options{
+		RealExecutable: os.Args[0],
+		RealArgs:       []string{"-test.run=TestAccountSnapshotHelperProcess", "--"},
+		Environment: append(
+			os.Environ(),
+			"GO_WANT_ACCOUNT_SNAPSHOT_HELPER=1",
+			"CODEX_MUX_TEST_RESPONSE_DIR="+responseDir,
+		),
+		Store:  store,
+		Output: io.Discard,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, account := range store.Accounts() {
+		if _, err := multiplexer.startChild(context.Background(), account); err != nil {
+			multiplexer.Close()
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(multiplexer.Close)
+	return multiplexer, store.Accounts(), responseDir
+}
+
+func waitForAccountSnapshotResponses(t *testing.T, responseDir string, accounts []state.Account) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		ready := true
+		for _, account := range accounts {
+			if _, err := os.Stat(filepath.Join(responseDir, filepath.Base(account.CodexHome))); err != nil {
+				if !os.IsNotExist(err) {
+					t.Fatal(err)
+				}
+				ready = false
+			}
+		}
+		if ready {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("responsive children did not send account/read responses")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestAccountSnapshotHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_ACCOUNT_SNAPSHOT_HELPER") != "1" {
+		return
+	}
+	_, blocksAccountRead := os.Stat(filepath.Join(os.Getenv("CODEX_HOME"), "block-account-read"))
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		var request struct {
+			ID     string `json:"id"`
+			Method string `json:"method"`
+		}
+		if json.Unmarshal(scanner.Bytes(), &request) != nil || request.Method != "account/read" {
+			continue
+		}
+		if blocksAccountRead == nil {
+			time.Sleep(time.Hour)
+		}
+		_, _ = fmt.Fprintf(os.Stdout, `{"id":%q,"result":{"account":{"type":"api"}}}`+"\n", request.ID)
+		if responseDir := os.Getenv("CODEX_MUX_TEST_RESPONSE_DIR"); responseDir != "" {
+			_ = os.WriteFile(filepath.Join(responseDir, filepath.Base(os.Getenv("CODEX_HOME"))), []byte("1"), 0o600)
+		}
+	}
+	os.Exit(0)
 }
 
 func TestPlanLabel(t *testing.T) {

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -75,10 +75,12 @@ type Multiplexer struct {
 	eventsMu sync.RWMutex
 	events   map[chan Event]struct{}
 
-	profileMu     sync.Mutex
-	profileClient *http.Client
-	profileCache  map[string]profileCacheEntry
-	now           func() time.Time
+	profileMu       sync.Mutex
+	profileClient   *http.Client
+	profileEndpoint string
+	profileCache    map[string]profileCacheEntry
+	profilePending  map[string]bool
+	now             func() time.Time
 
 	resetCreditsMu       sync.Mutex
 	resetCreditsCache    map[string]resetCreditsCacheEntry
@@ -106,8 +108,10 @@ func New(options Options) (*Multiplexer, error) {
 		externalRoutes:       make(map[string]externalRoute),
 		serverRoutes:         make(map[string]serverRequestRoute),
 		events:               make(map[chan Event]struct{}),
-		profileClient:        &http.Client{Timeout: 10 * time.Second},
+		profileClient:        &http.Client{Timeout: 15 * time.Second},
+		profileEndpoint:      profileURL,
 		profileCache:         make(map[string]profileCacheEntry),
+		profilePending:       make(map[string]bool),
 		now:                  time.Now,
 		resetCreditsCache:    make(map[string]resetCreditsCacheEntry),
 		resetCreditsEndpoint: rateLimitResetCreditsURL,

--- a/internal/mux/profile.go
+++ b/internal/mux/profile.go
@@ -40,7 +40,7 @@ type profileResponse struct {
 }
 
 func (m *Multiplexer) profileImageURL(ctx context.Context, account state.Account) string {
-	now := time.Now()
+	now := m.now()
 	m.profileMu.Lock()
 	cached, ok := m.profileCache[account.ID]
 	m.profileMu.Unlock()
@@ -51,7 +51,7 @@ func (m *Multiplexer) profileImageURL(ctx context.Context, account state.Account
 	imageURL, err := fetchProfileImageURL(
 		ctx,
 		m.profileClient,
-		profileURL,
+		m.profileEndpoint,
 		filepath.Join(account.CodexHome, "auth.json"),
 	)
 	if err != nil {
@@ -60,10 +60,39 @@ func (m *Multiplexer) profileImageURL(ctx context.Context, account state.Account
 	m.profileMu.Lock()
 	m.profileCache[account.ID] = profileCacheEntry{
 		imageURL:  imageURL,
-		expiresAt: now.Add(profileCacheTTL),
+		expiresAt: m.now().Add(profileCacheTTL),
 	}
 	m.profileMu.Unlock()
 	return imageURL
+}
+
+// profileImageURLCachedOrSchedule keeps the cosmetic profile lookup off the
+// subscription-list critical path. A slow ChatGPT profile endpoint must not
+// hide otherwise connected subscriptions from the account menu.
+func (m *Multiplexer) profileImageURLCachedOrSchedule(account state.Account) string {
+	now := m.now()
+	m.profileMu.Lock()
+	cached, ok := m.profileCache[account.ID]
+	if ok && now.Before(cached.expiresAt) {
+		m.profileMu.Unlock()
+		return cached.imageURL
+	}
+	if m.profilePending[account.ID] {
+		m.profileMu.Unlock()
+		return ""
+	}
+	m.profilePending[account.ID] = true
+	m.profileMu.Unlock()
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		_ = m.profileImageURL(ctx, account)
+		m.profileMu.Lock()
+		delete(m.profilePending, account.ID)
+		m.profileMu.Unlock()
+	}()
+	return ""
 }
 
 func fetchProfileImageURL(

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "check": "npm run check:go && npm run check:js && npm run check:python && npm run check:shell",
     "check:go": "go test ./... && go vet ./...",
-    "check:js": "node --check ui/account-menu.js && node --check ui/thread-subscription.js && node --check ui/ui-test-bridge.cjs",
+    "check:js": "node --check ui/account-menu.js && node --check ui/thread-subscription.js && node --check ui/ui-test-bridge.cjs && node --test ui/account-menu.test.cjs",
     "check:python": "python3 -m py_compile scripts/patch_app.py scripts/check_release.py",
     "check:shell": "bash -n install.sh",
     "release:check": "python3 scripts/check_release.py"

--- a/scripts/patch_app.py
+++ b/scripts/patch_app.py
@@ -1281,6 +1281,35 @@ def patch_renderer(extracted: Path, token: str) -> None:
     thread_bundle_path.write_text(thread_bundle, encoding="utf-8")
 
 
+def disable_updater_lifecycle(extracted: Path) -> None:
+    """Keep every updater entry point (launch gate, menu, IPC) from starting Sparkle."""
+    updater_anchor = (
+        "initializeUpdater(){return this.options.enableUpdater?"
+        "(this.updaterInitialization??=this.initializeUpdaterOnce(),"
+        "this.updaterInitialization):Promise.resolve()}"
+    )
+    matches = [
+        path
+        for path in (extracted / ".vite" / "build").glob("*.js")
+        if updater_anchor in path.read_text(encoding="utf-8")
+    ]
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"expected one desktop updater lifecycle bundle, found {len(matches)}"
+        )
+    bundle_path = matches[0]
+    bundle = bundle_path.read_text(encoding="utf-8")
+    if bundle.count(updater_anchor) != 1:
+        raise RuntimeError("could not find the desktop updater lifecycle")
+    bundle = bundle.replace(
+        updater_anchor,
+        "initializeUpdater(){return this.lastUnavailableReason="
+        f"`disabled by {DESKTOP_PROFILE_NAME}`,Promise.resolve()}}",
+        1,
+    )
+    bundle_path.write_text(bundle, encoding="utf-8")
+
+
 def patch_desktop_profile(
     extracted: Path, installed_computer_use_app: Path
 ) -> None:
@@ -1326,6 +1355,7 @@ def patch_desktop_profile(
     if updater_replacements != 1:
         raise RuntimeError("could not disable updates in the copied ChatGPT app")
     bootstrap_path.write_text(bootstrap, encoding="utf-8")
+    disable_updater_lifecycle(extracted)
 
     main_files = list((extracted / ".vite" / "build").glob("main-*.js"))
     if len(main_files) != 1:

--- a/scripts/patch_app.py
+++ b/scripts/patch_app.py
@@ -891,6 +891,22 @@ def patch_renderer(extracted: Path, token: str) -> None:
         1,
     )
 
+    usage_query_pattern = re.compile(
+        r"queryKey:\[`rate-limit-status`\],queryFn:async\(\)=>\{try\{return await "
+        r"(?P<client>[A-Za-z_$][A-Za-z0-9_$]*)\.safeGet\(`/wham/usage`\)\}"
+    )
+    usage_query_matches = list(usage_query_pattern.finditer(bundle))
+    if len(usage_query_matches) != 1:
+        raise RuntimeError("could not find the native rate-limit status query")
+    usage_query = usage_query_matches[0]
+    bundle = (
+        bundle[: usage_query.start()]
+        + "queryKey:[`rate-limit-status`],queryFn:async()=>{try{return await "
+        "codexMuxFilterUsageStatus(await "
+        f"{usage_query.group('client')}.safeGet(`/wham/usage`))}}"
+        + bundle[usage_query.end() :]
+    )
+
     profile_query_anchor = (
         "let e=await c_.safeGet(`/wham/profiles/me`)"
         if build_6662

--- a/scripts/patch_app.py
+++ b/scripts/patch_app.py
@@ -50,9 +50,29 @@ TESTED_SOURCE_BUILDS = {
         "26.803.61601",
         "6396",
     ): "d5a44ed9e2f1db5f81dbbe85408aed256f3203c5b16f00817bb9d7cd941343cf",
+    (
+        "26.810.52044",
+        "6662",
+    ): "6e7e8791b8bf69a586ff994721fff518af391d9efdc66cd2e620dd2a4aedc90f",
 }
 EXPECTED_CUA_IDENTIFIER_REPLACEMENTS = 49
+EXPECTED_CUA_IDENTIFIER_REPLACEMENTS_BY_BUILD = {
+    ("26.803.61601", "6396"): 49,
+    ("26.810.52044", "6662"): 99,
+}
+DEFAULT_CUA_SERVICE_LAYOUT = (("Codex Computer Use.app", 17),)
+EXPECTED_CUA_SERVICE_LAYOUT_BY_BUILD = {
+    ("26.803.61601", "6396"): DEFAULT_CUA_SERVICE_LAYOUT,
+    ("26.810.52044", "6662"): (
+        ("Codex Computer Use.app", 17),
+        ("bin/mac/normal/Codex Computer Use.app", 13),
+    ),
+}
 EXPECTED_ASAR_CUA_IDENTIFIER_REPLACEMENTS = 17
+EXPECTED_ASAR_CUA_IDENTIFIER_REPLACEMENTS_BY_BUILD = {
+    ("26.803.61601", "6396"): 17,
+    ("26.810.52044", "6662"): 20,
+}
 
 
 def parse_args() -> argparse.Namespace:
@@ -297,14 +317,14 @@ def retire_stale_cached_computer_use_app() -> None:
     print(f"Stale cached Computer Use helper moved to {backup}")
 
 
-def patch_computer_use_identity(app: Path, team_identifier: str | None) -> None:
+def patch_computer_use_identity(
+    app: Path,
+    team_identifier: str | None,
+    expected_replacements: int = EXPECTED_CUA_IDENTIFIER_REPLACEMENTS,
+    service_layout: tuple[tuple[str, int], ...] = DEFAULT_CUA_SERVICE_LAYOUT,
+) -> None:
     """Give the copied CUA service an independent identity and trusted callers."""
     package = computer_use_package(app)
-    service = package / "Codex Computer Use.app"
-    executable = service / "Contents" / "MacOS" / "SkyComputerUseService"
-    if not executable.is_file():
-        raise RuntimeError("bundled Codex Computer Use service was not found")
-
     for profile in package.rglob("embedded.provisionprofile"):
         profile.unlink()
 
@@ -316,65 +336,94 @@ def patch_computer_use_identity(app: Path, team_identifier: str | None) -> None:
                 OPENAI_COMPUTER_USE_BUNDLE_IDENTIFIER,
                 COMPUTER_USE_BUNDLE_IDENTIFIER,
             )
-    if identifier_replacements != EXPECTED_CUA_IDENTIFIER_REPLACEMENTS:
+    if identifier_replacements != expected_replacements:
         raise RuntimeError(
             "expected "
-            f"{EXPECTED_CUA_IDENTIFIER_REPLACEMENTS} Computer Use identity "
+            f"{expected_replacements} Computer Use identity "
             f"references, found {identifier_replacements}"
         )
 
-    plist_path = service / "Contents" / "Info.plist"
-    with plist_path.open("rb") as handle:
-        info = plistlib.load(handle)
-    info["CFBundleIdentifier"] = COMPUTER_USE_BUNDLE_IDENTIFIER
-    info["CFBundleDisplayName"] = COMPUTER_USE_DISPLAY_NAME
-    info["CFBundleName"] = COMPUTER_USE_DISPLAY_NAME
-    for key in list(info):
-        if key.startswith("SU"):
-            del info[key]
-    with plist_path.open("wb") as handle:
-        plistlib.dump(info, handle, fmt=plistlib.FMT_BINARY, sort_keys=False)
-
-    if team_identifier is None:
-        return
-    binary = executable.read_bytes()
-    replacement = arm64_swift_small_string(team_identifier)
-    for original_team, description in (
-        (OPENAI_INTERNAL_TEAM_IDENTIFIER, "internal"),
-        (OPENAI_DISTRIBUTION_TEAM_IDENTIFIER, "distribution"),
-    ):
-        original = arm64_swift_small_string(original_team)
-        match_count = binary.count(original)
-        if match_count != 2:
-            raise RuntimeError(
-                f"expected two Computer Use {description}-team checks, "
-                f"found {match_count}; the official app layout may have changed"
-            )
-        binary = binary.replace(original, replacement)
-
-        raw_original = original_team.encode("ascii")
-        raw_replacement = team_identifier.encode("ascii")
-        raw_match_count = binary.count(raw_original)
-        expected_raw_matches = 1 if description == "internal" else 17
-        if raw_match_count != expected_raw_matches:
-            raise RuntimeError(
-                f"expected {expected_raw_matches} Computer Use {description}-team "
-                f"constants, found {raw_match_count}; the official app layout may have changed"
-            )
-        binary = binary.replace(raw_original, raw_replacement)
-
-    original_bundle_id = b"com.openai.codex\0"
-    replacement_bundle_id = DESKTOP_BUNDLE_IDENTIFIER.encode("ascii") + b"\0"
-    if len(replacement_bundle_id) != len(original_bundle_id):
+    expected_service_paths = {relative for relative, _ in service_layout}
+    actual_service_paths = {
+        str(candidate.relative_to(package))
+        for candidate in package.rglob("Codex Computer Use.app")
+        if candidate.is_dir()
+    }
+    if actual_service_paths != expected_service_paths:
         raise RuntimeError(
-            "the independent bundle identifier must match the CUA identifier length"
+            "unexpected Computer Use service layout: "
+            f"expected {sorted(expected_service_paths)}, "
+            f"found {sorted(actual_service_paths)}"
         )
-    if binary.count(original_bundle_id) != 1:
-        raise RuntimeError("could not find the Computer Use production bundle ID")
-    executable.write_bytes(binary.replace(original_bundle_id, replacement_bundle_id))
+
+    for relative, expected_distribution_matches in service_layout:
+        service = package / relative
+        executable = service / "Contents" / "MacOS" / "SkyComputerUseService"
+        if not executable.is_file():
+            raise RuntimeError(f"bundled Computer Use service was not found: {relative}")
+
+        plist_path = service / "Contents" / "Info.plist"
+        with plist_path.open("rb") as handle:
+            info = plistlib.load(handle)
+        info["CFBundleIdentifier"] = COMPUTER_USE_BUNDLE_IDENTIFIER
+        info["CFBundleDisplayName"] = COMPUTER_USE_DISPLAY_NAME
+        info["CFBundleName"] = COMPUTER_USE_DISPLAY_NAME
+        for key in list(info):
+            if key.startswith("SU"):
+                del info[key]
+        with plist_path.open("wb") as handle:
+            plistlib.dump(info, handle, fmt=plistlib.FMT_BINARY, sort_keys=False)
+
+        if team_identifier is None:
+            continue
+        binary = executable.read_bytes()
+        replacement = arm64_swift_small_string(team_identifier)
+        for original_team, description, expected_raw_matches in (
+            (OPENAI_INTERNAL_TEAM_IDENTIFIER, "internal", 1),
+            (
+                OPENAI_DISTRIBUTION_TEAM_IDENTIFIER,
+                "distribution",
+                expected_distribution_matches,
+            ),
+        ):
+            original = arm64_swift_small_string(original_team)
+            match_count = binary.count(original)
+            if match_count != 2:
+                raise RuntimeError(
+                    f"expected two Computer Use {description}-team checks in "
+                    f"{relative}, found {match_count}; the official app layout may "
+                    "have changed"
+                )
+            binary = binary.replace(original, replacement)
+
+            raw_original = original_team.encode("ascii")
+            raw_replacement = team_identifier.encode("ascii")
+            raw_match_count = binary.count(raw_original)
+            if raw_match_count != expected_raw_matches:
+                raise RuntimeError(
+                    f"expected {expected_raw_matches} Computer Use {description}-team "
+                    f"constants in {relative}, found {raw_match_count}; the official "
+                    "app layout may have changed"
+                )
+            binary = binary.replace(raw_original, raw_replacement)
+
+        original_bundle_id = b"com.openai.codex\0"
+        replacement_bundle_id = DESKTOP_BUNDLE_IDENTIFIER.encode("ascii") + b"\0"
+        if len(replacement_bundle_id) != len(original_bundle_id):
+            raise RuntimeError(
+                "the independent bundle identifier must match the CUA identifier length"
+            )
+        if binary.count(original_bundle_id) != 1:
+            raise RuntimeError(
+                f"could not find the Computer Use production bundle ID in {relative}"
+            )
+        executable.write_bytes(binary.replace(original_bundle_id, replacement_bundle_id))
 
 
-def patch_asar_computer_use_identity(extracted: Path) -> None:
+def patch_asar_computer_use_identity(
+    extracted: Path,
+    expected_replacements: int = EXPECTED_ASAR_CUA_IDENTIFIER_REPLACEMENTS,
+) -> None:
     """Keep desktop launch, temp-file, and service references on the new CUA ID."""
     replacements = 0
     for candidate in extracted.rglob("*"):
@@ -384,10 +433,10 @@ def patch_asar_computer_use_identity(extracted: Path) -> None:
                 OPENAI_COMPUTER_USE_BUNDLE_IDENTIFIER,
                 COMPUTER_USE_BUNDLE_IDENTIFIER,
             )
-    if replacements != EXPECTED_ASAR_CUA_IDENTIFIER_REPLACEMENTS:
+    if replacements != expected_replacements:
         raise RuntimeError(
             "expected "
-            f"{EXPECTED_ASAR_CUA_IDENTIFIER_REPLACEMENTS} Computer Use references "
+            f"{expected_replacements} Computer Use references "
             f"in app.asar, found {replacements}"
         )
 
@@ -415,6 +464,7 @@ def sign_native_code_tree(root: Path, identity: str) -> None:
 
 TEAM_SCOPED_ENTITLEMENTS = (
     "com.apple.application-identifier",
+    "com.apple.developer.aps-environment",
     "com.apple.developer.team-identifier",
     "com.apple.security.application-groups",
     "keychain-access-groups",
@@ -543,63 +593,75 @@ def sign_runtime_bundle(
 
 def capture_computer_use_entitlements(
     app: Path,
+    service_layout: tuple[tuple[str, int], ...] = DEFAULT_CUA_SERVICE_LAYOUT,
 ) -> dict[Path, dict[str, object] | None]:
-    service = computer_use_package(app) / "Codex Computer Use.app"
-    if not service.is_dir():
-        raise RuntimeError("bundled Codex Computer Use service was not found")
-    return {
-        executable.relative_to(service): sanitized_runtime_entitlements(executable)
-        for executable in service.rglob("*")
-        if is_mach_o(executable)
-    }
+    package = computer_use_package(app)
+    entitlements: dict[Path, dict[str, object] | None] = {}
+    for relative, _ in service_layout:
+        service = package / relative
+        if not service.is_dir():
+            raise RuntimeError(f"bundled Computer Use service was not found: {relative}")
+        entitlements.update(
+            {
+                executable.relative_to(package): sanitized_runtime_entitlements(
+                    executable
+                )
+                for executable in service.rglob("*")
+                if is_mach_o(executable)
+            }
+        )
+    return entitlements
 
 
 def sign_computer_use_code(
     app: Path,
     identity: str,
     preserved_entitlements: dict[Path, dict[str, object] | None],
+    service_layout: tuple[tuple[str, int], ...] = DEFAULT_CUA_SERVICE_LAYOUT,
 ) -> None:
     """Keep the Computer Use service and its callers on one signing team."""
     resources = app / "Contents" / "Resources"
-    service = computer_use_package(app) / "Codex Computer Use.app"
-    if not service.is_dir():
-        raise RuntimeError("bundled Codex Computer Use service was not found")
+    package = computer_use_package(app)
+    for relative, _ in service_layout:
+        service = package / relative
+        if not service.is_dir():
+            raise RuntimeError(f"bundled Computer Use service was not found: {relative}")
 
-    for executable in sorted(
-        (candidate for candidate in service.rglob("*") if is_mach_o(candidate)),
-        key=lambda candidate: len(candidate.parts),
-        reverse=True,
-    ):
-        relative = executable.relative_to(service)
-        sign_runtime_executable(
-            executable,
-            identity,
-            entitlements=preserved_entitlements.get(relative),
-        )
+        for executable in sorted(
+            (candidate for candidate in service.rglob("*") if is_mach_o(candidate)),
+            key=lambda candidate: len(candidate.parts),
+            reverse=True,
+        ):
+            executable_relative = executable.relative_to(package)
+            sign_runtime_executable(
+                executable,
+                identity,
+                entitlements=preserved_entitlements.get(executable_relative),
+            )
 
-    bundle_suffixes = {".app", ".appex", ".bundle", ".framework", ".xpc"}
-    bundles = [
-        candidate
-        for candidate in service.rglob("*")
-        if candidate.is_dir() and candidate.suffix in bundle_suffixes
-    ]
-    bundles.append(service)
-    for bundle in sorted(
-        set(bundles),
-        key=lambda candidate: len(candidate.parts),
-        reverse=True,
-    ):
-        identifier = (
-            COMPUTER_USE_BUNDLE_IDENTIFIER if bundle == service else None
-        )
-        executable = bundle_main_executable(bundle)
-        entitlements = (
-            preserved_entitlements.get(executable.relative_to(service))
-            if executable is not None
-            else None
-        )
-        sign_runtime_bundle(bundle, identity, identifier, entitlements)
-        run(["codesign", "--verify", "--deep", "--strict", str(bundle)])
+        bundle_suffixes = {".app", ".appex", ".bundle", ".framework", ".xpc"}
+        bundles = [
+            candidate
+            for candidate in service.rglob("*")
+            if candidate.is_dir() and candidate.suffix in bundle_suffixes
+        ]
+        bundles.append(service)
+        for bundle in sorted(
+            set(bundles),
+            key=lambda candidate: len(candidate.parts),
+            reverse=True,
+        ):
+            identifier = (
+                COMPUTER_USE_BUNDLE_IDENTIFIER if bundle == service else None
+            )
+            executable = bundle_main_executable(bundle)
+            entitlements = (
+                preserved_entitlements.get(executable.relative_to(package))
+                if executable is not None
+                else None
+            )
+            sign_runtime_bundle(bundle, identity, identifier, entitlements)
+            run(["codesign", "--verify", "--deep", "--strict", str(bundle)])
 
     for executable_name in ("node", "node_repl"):
         executable = resources / "cua_node" / "bin" / executable_name
@@ -613,12 +675,21 @@ def sign_computer_use_code(
 
 
 def sign_independent_app(
-    app: Path, identity: str, team_identifier: str | None
+    app: Path,
+    identity: str,
+    team_identifier: str | None,
+    expected_cua_replacements: int = EXPECTED_CUA_IDENTIFIER_REPLACEMENTS,
+    service_layout: tuple[tuple[str, int], ...] = DEFAULT_CUA_SERVICE_LAYOUT,
 ) -> None:
     """Apply one stable identity throughout the modified Electron bundle."""
-    computer_use_entitlements = capture_computer_use_entitlements(app)
-    patch_computer_use_identity(app, team_identifier)
-    sign_computer_use_code(app, identity, computer_use_entitlements)
+    computer_use_entitlements = capture_computer_use_entitlements(app, service_layout)
+    patch_computer_use_identity(
+        app,
+        team_identifier,
+        expected_cua_replacements,
+        service_layout,
+    )
+    sign_computer_use_code(app, identity, computer_use_entitlements, service_layout)
     run(
         [
             "codesign",
@@ -709,6 +780,18 @@ def ensure_asar_tool() -> Path:
     return asar
 
 
+def replace_javascript_identifiers(source: str, replacements: dict[str, str]) -> str:
+    """Retarget injected source to the minified imports in a supported build."""
+    for original, replacement in replacements.items():
+        pattern = rf"(?<![A-Za-z0-9_$]){re.escape(original)}(?![A-Za-z0-9_$])"
+        source, count = re.subn(pattern, replacement, source)
+        if count == 0:
+            raise RuntimeError(
+                f"could not retarget injected JavaScript identifier {original!r}"
+            )
+    return source
+
+
 def patch_renderer(extracted: Path, token: str) -> None:
     webview = extracted / "webview"
     index_path = webview / "index.html"
@@ -737,20 +820,42 @@ def patch_renderer(extracted: Path, token: str) -> None:
     component = (PROJECT_ROOT / "ui" / "account-menu.js").read_text(encoding="utf-8")
     component = component.replace("__CODEX_MUX_CONTROL_PORT__", str(CONTROL_PORT))
     component = component.replace("__CODEX_MUX_CONTROL_TOKEN__", token)
-    component_anchor = "function wXc({sidebarFooter:e,triggerButton:t})"
+    build_6662 = "function Icl(e){let t=(0,Vcl.c)(248)," in bundle
+    if build_6662:
+        component = replace_javascript_identifiers(
+            component,
+            {
+                "e7": "$5",
+                "kXc": "Hcl",
+                "Lo": "Fo",
+                "BW": "RU",
+                "QLs": "E$s",
+                "_H": "GV",
+                "S2": "E0",
+                "CH": "ZV",
+                "jLa": "x$a",
+                "lt": "ct",
+            },
+        )
+        component_anchor = "function Icl(e){let t=(0,Vcl.c)(248),"
+    else:
+        component_anchor = "function wXc({sidebarFooter:e,triggerButton:t})"
     if bundle.count(component_anchor) != 1:
         raise RuntimeError("could not find the native ChatGPT profile menu component")
     bundle = bundle.replace(component_anchor, component + "\n" + component_anchor, 1)
 
+    rpc_wrapper = "J9" if build_6662 else "q9"
+    status_rpc_wrapper = "q9" if build_6662 else "K9"
     plugin_rpc_mapping_anchors = (
-        '"list-apps":q9((e,{priority:t,source:n,timeoutMs:r,trace:i,...a})=>'
-        "e.sendRequest(`app/list`,a,",
-        '"list-installed-apps":q9((e,t)=>e.sendRequest(`app/installed`,t))',
-        '"read-apps":q9((e,t)=>e.sendRequest(`app/read`,t))',
-        '"login-mcp-server":q9((e,t)=>'
+        f'"list-apps":{rpc_wrapper}((e,{{priority:t,source:n,timeoutMs:r,'
+        "trace:i,...a})=>e.sendRequest(`app/list`,a,",
+        f'"list-installed-apps":{rpc_wrapper}((e,t)=>'
+        "e.sendRequest(`app/installed`,t))",
+        f'"read-apps":{rpc_wrapper}((e,t)=>e.sendRequest(`app/read`,t))',
+        f'"login-mcp-server":{rpc_wrapper}((e,t)=>'
         "e.sendRequest(`mcpServer/oauth/login`,t))",
-        '"list-mcp-server-status":K9((e,{priority:t,source:n,timeoutMs:r,'
-        "trace:i,...a})=>e.listMcpServers(a,",
+        f'"list-mcp-server-status":{status_rpc_wrapper}((e,{{priority:t,'
+        "source:n,timeoutMs:r,trace:i,...a})=>e.listMcpServers(a,",
         "listMcpServers(e,t){let n=JSON.stringify({options:t,params:e})",
         "let i=this.sendRequest(`mcpServerStatus/list`,e,t);",
     )
@@ -760,20 +865,37 @@ def patch_renderer(extracted: Path, token: str) -> None:
                 "could not verify the native Plugins request-to-RPC mapping"
             )
 
-    app_server_request_anchor = (
-        "function gm(e,t,n){return n==null?h6e.sendRequest(e,t):"
-        "h6e.sendRequest(e,t,n)}"
-    )
+    if build_6662:
+        app_server_request_anchor = (
+            "function Bp(e,t,n){return n==null?N8e.sendRequest(e,t):"
+            "N8e.sendRequest(e,t,n)}"
+        )
+        app_server_request_replacement = (
+            "function Bp(e,t,n){let r=codexMuxScopePluginRequest(e,t);"
+            "return n==null?N8e.sendRequest(e,r):N8e.sendRequest(e,r,n)}"
+        )
+    else:
+        app_server_request_anchor = (
+            "function gm(e,t,n){return n==null?h6e.sendRequest(e,t):"
+            "h6e.sendRequest(e,t,n)}"
+        )
+        app_server_request_replacement = (
+            "function gm(e,t,n){let r=codexMuxScopePluginRequest(e,t);"
+            "return n==null?h6e.sendRequest(e,r):h6e.sendRequest(e,r,n)}"
+        )
     if bundle.count(app_server_request_anchor) != 1:
         raise RuntimeError("could not find the native app-server request bridge")
     bundle = bundle.replace(
         app_server_request_anchor,
-        "function gm(e,t,n){let r=codexMuxScopePluginRequest(e,t);"
-        "return n==null?h6e.sendRequest(e,r):h6e.sendRequest(e,r,n)}",
+        app_server_request_replacement,
         1,
     )
 
-    profile_query_anchor = "let e=await T_.safeGet(`/wham/profiles/me`)"
+    profile_query_anchor = (
+        "let e=await c_.safeGet(`/wham/profiles/me`)"
+        if build_6662
+        else "let e=await T_.safeGet(`/wham/profiles/me`)"
+    )
     if bundle.count(profile_query_anchor) != 1:
         raise RuntimeError("could not find the native profile stats request")
     bundle = bundle.replace(
@@ -783,53 +905,95 @@ def patch_renderer(extracted: Path, token: str) -> None:
         1,
     )
 
-    native_usage_modal_anchor = "function QLs(e){"
+    native_usage_modal_name = "E$s" if build_6662 else "QLs"
+    native_usage_modal_anchor = f"function {native_usage_modal_name}(e){{"
     if bundle.count(native_usage_modal_anchor) != 1:
         raise RuntimeError("could not find the native Usage modal component")
     bundle = bundle.replace(
         native_usage_modal_anchor,
-        "function QLs(e){CodexMuxUseResetAccountState();",
+        f"function {native_usage_modal_name}(e){{CodexMuxUseResetAccountState();",
         1,
     )
 
-    reset_query_anchor = (
-        "function l6r(){let e=(0,$F.c)(1),t;return "
-        "e[0]===Symbol.for(`react.memo_cache_sentinel`)?"
-        "(t={queryKey:[`rate-limit-reset-credits`],queryFn:u6r,"
-        "refetchInterval:vm.ONE_MINUTE,staleTime:vm.FIVE_SECONDS},e[0]=t):"
-        "t=e[0],Lt(t)}"
-    )
+    if build_6662:
+        reset_query_anchor = (
+            "function Ooi(){let e=(0,SI.c)(1),t;return "
+            "e[0]===Symbol.for(`react.memo_cache_sentinel`)?"
+            "(t={queryKey:[`rate-limit-reset-credits`],queryFn:koi,"
+            "refetchInterval:Wp.ONE_MINUTE,staleTime:Wp.FIVE_SECONDS},e[0]=t):"
+            "t=e[0],It(t)}"
+        )
+        reset_query_replacement = (
+            "function Ooi(){let e=window.__codexMuxResetAccountId;return It({"
+            "queryKey:[`rate-limit-reset-credits`,e??`primary`],"
+            "queryFn:e?()=>codexMuxRateLimitResets(e):koi,"
+            "refetchInterval:Wp.ONE_MINUTE,staleTime:Wp.FIVE_SECONDS})}"
+        )
+    else:
+        reset_query_anchor = (
+            "function l6r(){let e=(0,$F.c)(1),t;return "
+            "e[0]===Symbol.for(`react.memo_cache_sentinel`)?"
+            "(t={queryKey:[`rate-limit-reset-credits`],queryFn:u6r,"
+            "refetchInterval:vm.ONE_MINUTE,staleTime:vm.FIVE_SECONDS},e[0]=t):"
+            "t=e[0],Lt(t)}"
+        )
+        reset_query_replacement = (
+            "function l6r(){let e=window.__codexMuxResetAccountId;return Lt({"
+            "queryKey:[`rate-limit-reset-credits`,e??`primary`],"
+            "queryFn:e?()=>codexMuxRateLimitResets(e):u6r,"
+            "refetchInterval:vm.ONE_MINUTE,staleTime:vm.FIVE_SECONDS})}"
+        )
     if bundle.count(reset_query_anchor) != 1:
         raise RuntimeError("could not find the native reset-credit query")
     bundle = bundle.replace(
         reset_query_anchor,
-        "function l6r(){let e=window.__codexMuxResetAccountId;return Lt({"
-        "queryKey:[`rate-limit-reset-credits`,e??`primary`],"
-        "queryFn:e?()=>codexMuxRateLimitResets(e):u6r,"
-        "refetchInterval:vm.ONE_MINUTE,staleTime:vm.FIVE_SECONDS})}",
+        reset_query_replacement,
         1,
     )
 
-    reset_mutation_anchor = (
-        "function d6r(){let e=(0,$F.c)(3),t=lt(),n=zO(),r;return "
-        "e[0]!==n||e[1]!==t?(r={mutationFn:f6r,onSuccess:(e,r)=>{"
-        "let{creditId:i}=r,a=e.code;if(a===`reset`||a===`already_redeemed`){"
-        "let n=e.code===`reset`?e.credit?.id??i:i;"
-        "t.setQueryData([`rate-limit-reset-credits`],e=>F3r(e,a,n))}"
-        "Promise.all([n([`rate-limit-status`]),n([`rate-limit-reset-credits`])])}},"
-        "e[0]=n,e[1]=t,e[2]=r):r=e[2],$t(r)}"
-    )
+    if build_6662:
+        reset_mutation_anchor = (
+            "function Aoi(){let e=(0,SI.c)(3),t=ct(),n=Uw(),r;return "
+            "e[0]!==n||e[1]!==t?(r={mutationFn:joi,onSuccess:(e,r)=>{"
+            "let{creditId:i}=r,a=e.code;if(a===`reset`||a===`already_redeemed`){"
+            "let n=e.code===`reset`?e.credit?.id??i:i;"
+            "t.setQueryData([`rate-limit-reset-credits`],e=>eoi(e,a,n))}"
+            "Promise.all([n([`rate-limit-status`]),n([`rate-limit-reset-credits`])])}},"
+            "e[0]=n,e[1]=t,e[2]=r):r=e[2],Qt(r)}"
+        )
+        reset_mutation_replacement = (
+            "function Aoi(){let e=ct(),t=Uw(),n=window.__codexMuxResetAccountId,"
+            "r=[`rate-limit-reset-credits`,n??`primary`];return Qt({"
+            "mutationFn:n?i=>codexMuxConsumeRateLimitReset(n,i):joi,"
+            "onSuccess:(n,i)=>{let{creditId:a}=i,o=n.code;"
+            "if(o===`reset`||o===`already_redeemed`){let t=o===`reset`?"
+            "n.credit?.id??a:a;e.setQueryData(r,e=>eoi(e,o,t))}"
+            "Promise.all([t([`rate-limit-status`]),t(r)])}})}"
+        )
+    else:
+        reset_mutation_anchor = (
+            "function d6r(){let e=(0,$F.c)(3),t=lt(),n=zO(),r;return "
+            "e[0]!==n||e[1]!==t?(r={mutationFn:f6r,onSuccess:(e,r)=>{"
+            "let{creditId:i}=r,a=e.code;if(a===`reset`||a===`already_redeemed`){"
+            "let n=e.code===`reset`?e.credit?.id??i:i;"
+            "t.setQueryData([`rate-limit-reset-credits`],e=>F3r(e,a,n))}"
+            "Promise.all([n([`rate-limit-status`]),n([`rate-limit-reset-credits`])])}},"
+            "e[0]=n,e[1]=t,e[2]=r):r=e[2],$t(r)}"
+        )
+        reset_mutation_replacement = (
+            "function d6r(){let e=lt(),t=zO(),n=window.__codexMuxResetAccountId,"
+            "r=[`rate-limit-reset-credits`,n??`primary`];return $t({"
+            "mutationFn:n?i=>codexMuxConsumeRateLimitReset(n,i):f6r,"
+            "onSuccess:(n,i)=>{let{creditId:a}=i,o=n.code;"
+            "if(o===`reset`||o===`already_redeemed`){let t=o===`reset`?"
+            "n.credit?.id??a:a;e.setQueryData(r,e=>F3r(e,o,t))}"
+            "Promise.all([t([`rate-limit-status`]),t(r)])}})}"
+        )
     if bundle.count(reset_mutation_anchor) != 1:
         raise RuntimeError("could not find the native reset-credit mutation")
     bundle = bundle.replace(
         reset_mutation_anchor,
-        "function d6r(){let e=lt(),t=zO(),n=window.__codexMuxResetAccountId,"
-        "r=[`rate-limit-reset-credits`,n??`primary`];return $t({"
-        "mutationFn:n?i=>codexMuxConsumeRateLimitReset(n,i):f6r,"
-        "onSuccess:(n,i)=>{let{creditId:a}=i,o=n.code;"
-        "if(o===`reset`||o===`already_redeemed`){let t=o===`reset`?"
-        "n.credit?.id??a:a;e.setQueryData(r,e=>F3r(e,o,t))}"
-        "Promise.all([t([`rate-limit-status`]),t(r)])}})}",
+        reset_mutation_replacement,
         1,
     )
 
@@ -842,40 +1006,66 @@ def patch_renderer(extracted: Path, token: str) -> None:
         1,
     )
 
-    usage_header_anchor = (
-        "let ve;t[46]===ge?ve=t[47]:"
-        "(ve=(0,k2.jsxs)(LL,{children:[ge,_e]}),t[46]=ge,t[47]=ve);"
-    )
+    if build_6662:
+        usage_header_anchor = (
+            "let _e;t[46]===he?_e=t[47]:"
+            "(_e=(0,I0.jsxs)(WL,{children:[he,ge]}),t[46]=he,t[47]=_e);"
+        )
+        usage_header_replacement = (
+            "let _e=(0,I0.jsxs)(WL,{children:[he,ge,"
+            "window.__codexMuxResetAccountSelector??null]});"
+        )
+    else:
+        usage_header_anchor = (
+            "let ve;t[46]===ge?ve=t[47]:"
+            "(ve=(0,k2.jsxs)(LL,{children:[ge,_e]}),t[46]=ge,t[47]=ve);"
+        )
+        usage_header_replacement = (
+            "let ve=(0,k2.jsxs)(LL,{children:[ge,_e,"
+            "window.__codexMuxResetAccountSelector??null]});"
+        )
     if bundle.count(usage_header_anchor) != 1:
         raise RuntimeError("could not find the native Usage sheet header")
     bundle = bundle.replace(
         usage_header_anchor,
-        "let ve=(0,k2.jsxs)(LL,{children:[ge,_e,"
-        "window.__codexMuxResetAccountSelector??null]});",
+        usage_header_replacement,
         1,
     )
 
-    usage_anchor = "usageItems:Ge"
+    usage_anchor = "usageItems:Ct" if build_6662 else "usageItems:Ge"
     if bundle.count(usage_anchor) != 1:
         raise RuntimeError("could not find the native ChatGPT usage menu slot")
     bundle = bundle.replace(
         usage_anchor,
-        "usageItems:(0,e7.jsx)(CodexMuxAccountMenu,{})",
+        (
+            "usageItems:(0,$5.jsx)(CodexMuxAccountMenu,{})"
+            if build_6662
+            else "usageItems:(0,e7.jsx)(CodexMuxAccountMenu,{})"
+        ),
         1,
     )
 
-    open_change_anchors = (
-        "triggerButton:Ke,onOpenChange:o,children:(0,e7.jsx)(bXc",
-        "return(0,e7.jsx)(vH,{open:a,onOpenChange:o,contentWidth:`panel`",
-    )
+    if build_6662:
+        open_change_anchors = (
+            "triggerButton:Dt,onOpenChange:l,children:P",
+            "open:s,onOpenChange:l,contentWidth:`panel`,triggerButton:Dt",
+        )
+        open_change_name = "l"
+    else:
+        open_change_anchors = (
+            "triggerButton:Ke,onOpenChange:o,children:(0,e7.jsx)(bXc",
+            "return(0,e7.jsx)(vH,{open:a,onOpenChange:o,contentWidth:`panel`",
+        )
+        open_change_name = "o"
     for anchor in open_change_anchors:
         if bundle.count(anchor) != 1:
             raise RuntimeError("could not find a native profile menu open-state hook")
         bundle = bundle.replace(
             anchor,
             anchor.replace(
-                "onOpenChange:o",
-                "onOpenChange:CodexMuxProfileMenuOpenChange(o)",
+                f"onOpenChange:{open_change_name}",
+                "onOpenChange:CodexMuxProfileMenuOpenChange("
+                f"{open_change_name})",
             ),
             1,
         )
@@ -902,49 +1092,105 @@ def patch_renderer(extracted: Path, token: str) -> None:
         )
     profile_bundle_path = profile_bundles[0]
     profile_bundle = profile_bundle_path.read_text(encoding="utf-8")
-    profile_avatar_anchor = (
-        "children:[(0,$.jsxs)(`div`,{className:`relative mb-4 size-20`,children:["
-    )
+    if build_6662:
+        profile_avatar_anchor = (
+            "avatar:(0,$.jsxs)($.Fragment,{children:["
+            "(0,$.jsxs)(`label`,{\"aria-disabled\":z.isPending,"
+            "className:Le(`group relative flex size-20 rounded-full outline-none "
+            "focus-within:ring-1 focus-within:ring-ring`,"
+        )
+        profile_avatar_replacement = (
+            "avatar:(0,$.jsxs)($.Fragment,{children:["
+            "globalThis.CodexMuxProfileAvatarStack?.("
+            "{onSelect:()=>M.refetch()})??null,"
+            "(0,$.jsxs)(`label`,{\"aria-disabled\":z.isPending,"
+            "className:Le(globalThis.CodexMuxProfileAvatarStack?`hidden`:"
+            "`group relative flex size-20 rounded-full outline-none "
+            "focus-within:ring-1 focus-within:ring-ring`,"
+        )
+    else:
+        profile_avatar_anchor = (
+            "children:[(0,$.jsxs)(`div`,{className:`relative mb-4 size-20`,"
+            "children:["
+        )
+        profile_avatar_replacement = (
+            "children:[globalThis.CodexMuxProfileAvatarStack?.("
+            "{onSelect:()=>A.refetch()})??null,"
+            "(0,$.jsxs)(`div`,{className:"
+            "globalThis.CodexMuxProfileAvatarStack?"
+            "`hidden`:`relative mb-4 size-20`,children:["
+        )
     if profile_bundle.count(profile_avatar_anchor) != 1:
         raise RuntimeError("could not find the native Profile avatar")
     profile_bundle = profile_bundle.replace(
         profile_avatar_anchor,
-        "children:[globalThis.CodexMuxProfileAvatarStack?.("
-        "{onSelect:()=>A.refetch()})??null,"
-        "(0,$.jsxs)(`div`,{className:"
-        "globalThis.CodexMuxProfileAvatarStack?"
-        "`hidden`:`relative mb-4 size-20`,children:[",
+        profile_avatar_replacement,
         1,
     )
 
-    profile_name_anchor = "className:`flex w-full justify-center`"
+    profile_name_anchor = (
+        "displayName:Ze??(0,$.jsx)(o,{id:`profile.nameFallback`,"
+        "defaultMessage:`ChatGPT user`,description:`Fallback profile display name`})"
+        if build_6662
+        else "className:`flex w-full justify-center`"
+    )
     if profile_bundle.count(profile_name_anchor) != 1:
         raise RuntimeError("could not find the native Profile display name")
     profile_bundle = profile_bundle.replace(
         profile_name_anchor,
-        "className:globalThis.__codexMuxSelectedProfileAccountId&&!A.isFetching?"
-        "`flex w-full justify-center`:`hidden`",
+        (
+            "displayName:globalThis.__codexMuxSelectedProfileAccountId?"
+            "(Ze??(0,$.jsx)(o,{id:`profile.nameFallback`,"
+            "defaultMessage:`ChatGPT user`,"
+            "description:`Fallback profile display name`})):null"
+            if build_6662
+            else "className:globalThis.__codexMuxSelectedProfileAccountId&&"
+            "!A.isFetching?`flex w-full justify-center`:`hidden`"
+        ),
         1,
     )
     profile_identity_anchor = (
-        "className:`mt-1 flex min-h-7 items-center gap-1.5 text-base leading-5 "
+        "username:Ke==null?null:(0,$.jsx)(o,{id:`profile.usernameValue`,"
+        "defaultMessage:`@{username}`,"
+        "description:`Profile username shown with an at-sign prefix`,"
+        "values:{username:Ke}})"
+        if build_6662
+        else "className:`mt-1 flex min-h-7 items-center gap-1.5 text-base leading-5 "
         "font-normal text-token-text-tertiary`"
     )
     if profile_bundle.count(profile_identity_anchor) != 1:
         raise RuntimeError("could not find the native Profile username and plan badge")
     profile_bundle = profile_bundle.replace(
         profile_identity_anchor,
-        "className:globalThis.__codexMuxSelectedProfileAccountId&&!A.isFetching?"
-        "`mt-1 flex min-h-7 items-center gap-1.5 text-base leading-5 font-normal "
-        "text-token-text-tertiary`:`hidden`",
+        (
+            "username:globalThis.__codexMuxSelectedProfileAccountId&&Ke!=null?"
+            "(0,$.jsx)(o,{id:`profile.usernameValue`,"
+            "defaultMessage:`@{username}`,"
+            "description:`Profile username shown with an at-sign prefix`,"
+            "values:{username:Ke}}):null"
+            if build_6662
+            else "className:globalThis.__codexMuxSelectedProfileAccountId&&"
+            "!A.isFetching?`mt-1 flex min-h-7 items-center gap-1.5 text-base "
+            "leading-5 font-normal text-token-text-tertiary`:`hidden`"
+        ),
         1,
     )
     profile_bundle_path.write_text(profile_bundle, encoding="utf-8")
 
-    plugin_scope_anchor = "action:F,children:w})"
+    plugin_scope_anchor = (
+        "ee=(0,tc.jsxs)(tc.Fragment,{children:[H,U]})"
+        if build_6662
+        else "action:F,children:w})"
+    )
+    plugin_scope_replacement = (
+        "ee=(0,tc.jsxs)(tc.Fragment,{children:[globalThis.CodexMuxPluginScope?.()??null,H,U]})"
+        if build_6662
+        else "action:F,children:[globalThis.CodexMuxPluginScope?.()??null,w]})"
+    )
+    plugin_bundle_glob = "plugins-page-*.js" if build_6662 else "plugins-settings-*.js"
     plugin_bundles = [
         path
-        for path in (webview / "assets").glob("plugins-settings-*.js")
+        for path in (webview / "assets").glob(plugin_bundle_glob)
         if plugin_scope_anchor in path.read_text(encoding="utf-8")
     ]
     if len(plugin_bundles) != 1:
@@ -957,12 +1203,21 @@ def patch_renderer(extracted: Path, token: str) -> None:
         raise RuntimeError("could not find the native Plugins settings content")
     plugin_bundle = plugin_bundle.replace(
         plugin_scope_anchor,
-        "action:F,children:[globalThis.CodexMuxPluginScope?.()??null,w]})",
+        plugin_scope_replacement,
         1,
     )
     plugin_bundle_path.write_text(plugin_bundle, encoding="utf-8")
 
-    thread_bundles = list((webview / "assets").glob("local-conversation-thread-*.js"))
+    thread_component_anchor = (
+        "function bE(){let e=(0,SE.c)(1)"
+        if build_6662
+        else "function bE(){let e=(0,wE.c)(57)"
+    )
+    thread_bundles = [
+        path
+        for path in (webview / "assets").glob("local-conversation-thread-*.js")
+        if thread_component_anchor in path.read_text(encoding="utf-8")
+    ]
     if len(thread_bundles) != 1:
         raise RuntimeError(
             f"expected one local conversation renderer bundle, found {len(thread_bundles)}"
@@ -976,7 +1231,20 @@ def patch_renderer(extracted: Path, token: str) -> None:
         "__CODEX_MUX_CONTROL_PORT__", str(CONTROL_PORT)
     )
     thread_component = thread_component.replace("__CODEX_MUX_CONTROL_TOKEN__", token)
-    thread_component_anchor = "function bE(){let e=(0,wE.c)(57)"
+    if build_6662:
+        thread_component = replace_javascript_identifiers(
+            thread_component,
+            {
+                "$n": "jf",
+                "sr": "Pa",
+                "TE": "jy",
+                "zE": "CE",
+                "K": "q",
+            },
+        )
+        summary_component = "CE"
+    else:
+        summary_component = "zE"
     if thread_bundle.count(thread_component_anchor) != 1:
         raise RuntimeError("could not find the native thread summary sources component")
     thread_bundle = thread_bundle.replace(
@@ -989,7 +1257,9 @@ def patch_renderer(extracted: Path, token: str) -> None:
         raise RuntimeError("could not find the native thread summary section list")
     thread_bundle = thread_bundle.replace(
         summary_children_anchor,
-        "children:[c,l,u,d,f,(0,zE.jsx)(CodexMuxThreadSubscription,{}),p,m,h,g,_,v,y,b,x]",
+        "children:[c,l,u,d,f,(0,"
+        f"{summary_component}.jsx)(CodexMuxThreadSubscription,{{}}),"
+        "p,m,h,g,_,v,y,b,x]",
         1,
     )
     thread_bundle_path.write_text(thread_bundle, encoding="utf-8")
@@ -1210,7 +1480,13 @@ def patch_app(
         original_asar = resources / "app.asar"
         print("Patching desktop profile and renderer…")
         run([str(asar), "extract", str(original_asar), str(extracted)])
-        patch_asar_computer_use_identity(extracted)
+        expected_cua_replacements = (
+            EXPECTED_ASAR_CUA_IDENTIFIER_REPLACEMENTS_BY_BUILD.get(
+                (source_version, source_build),
+                EXPECTED_ASAR_CUA_IDENTIFIER_REPLACEMENTS,
+            )
+        )
+        patch_asar_computer_use_identity(extracted, expected_cua_replacements)
         patch_desktop_profile(extracted, installed_computer_use_app)
         patch_renderer(extracted, token)
         sign_native_code_tree(extracted, signing_identity)
@@ -1252,7 +1528,23 @@ def patch_app(
 
         patch_info_plist(staged_app, original_asar, team_identifier)
         print(f"Signing independent app copy with {signing_identity}…")
-        sign_independent_app(staged_app, signing_identity, team_identifier)
+        expected_cua_identity_replacements = (
+            EXPECTED_CUA_IDENTIFIER_REPLACEMENTS_BY_BUILD.get(
+                (source_version, source_build),
+                EXPECTED_CUA_IDENTIFIER_REPLACEMENTS,
+            )
+        )
+        cua_service_layout = EXPECTED_CUA_SERVICE_LAYOUT_BY_BUILD.get(
+            (source_version, source_build),
+            DEFAULT_CUA_SERVICE_LAYOUT,
+        )
+        sign_independent_app(
+            staged_app,
+            signing_identity,
+            team_identifier,
+            expected_cua_identity_replacements,
+            cua_service_layout,
+        )
         verify_signed_code(
             staged_app,
             DESKTOP_BUNDLE_IDENTIFIER,

--- a/scripts/patch_app.py
+++ b/scripts/patch_app.py
@@ -54,11 +54,16 @@ TESTED_SOURCE_BUILDS = {
         "26.810.52044",
         "6662",
     ): "6e7e8791b8bf69a586ff994721fff518af391d9efdc66cd2e620dd2a4aedc90f",
+    (
+        "26.901.22334",
+        "7746",
+    ): "405f0e1600fc63851abe4c763ec0546f56c32da312c2c2745e2b997c579ce0d0",
 }
 EXPECTED_CUA_IDENTIFIER_REPLACEMENTS = 49
 EXPECTED_CUA_IDENTIFIER_REPLACEMENTS_BY_BUILD = {
     ("26.803.61601", "6396"): 49,
     ("26.810.52044", "6662"): 99,
+    ("26.901.22334", "7746"): 49,
 }
 DEFAULT_CUA_SERVICE_LAYOUT = (("Codex Computer Use.app", 17),)
 EXPECTED_CUA_SERVICE_LAYOUT_BY_BUILD = {
@@ -67,11 +72,13 @@ EXPECTED_CUA_SERVICE_LAYOUT_BY_BUILD = {
         ("Codex Computer Use.app", 17),
         ("bin/mac/normal/Codex Computer Use.app", 13),
     ),
+    ("26.901.22334", "7746"): DEFAULT_CUA_SERVICE_LAYOUT,
 }
 EXPECTED_ASAR_CUA_IDENTIFIER_REPLACEMENTS = 17
 EXPECTED_ASAR_CUA_IDENTIFIER_REPLACEMENTS_BY_BUILD = {
     ("26.803.61601", "6396"): 17,
     ("26.810.52044", "6662"): 20,
+    ("26.901.22334", "7746"): 16,
 }
 
 
@@ -700,6 +707,48 @@ def sign_independent_app(
             str(app / "Contents" / "Resources" / "codex"),
         ]
     )
+    # Seal every nested desktop bundle from the leaves upward. This keeps the
+    # copied app independently valid even when the official source contains a
+    # stale nested signature (newer builds add both Chromium frameworks and a
+    # Dock tile plug-in).
+    embedded_suffixes = {
+        ".app",
+        ".appex",
+        ".bundle",
+        ".docktileplugin",
+        ".framework",
+        ".xpc",
+    }
+    embedded_roots = tuple(
+        root
+        for root in (app / "Contents" / "Frameworks", app / "Contents" / "PlugIns")
+        if root.is_dir()
+    )
+    for embedded_executable in sorted(
+        (
+            candidate
+            for root in embedded_roots
+            for candidate in root.rglob("*")
+            if is_mach_o(candidate)
+        ),
+        key=lambda candidate: len(candidate.parts),
+        reverse=True,
+    ):
+        sign_runtime_executable(embedded_executable, identity)
+    embedded_bundles = sorted(
+        (
+            candidate
+            for root in embedded_roots
+            for candidate in root.rglob("*")
+            if candidate.is_dir()
+            and not candidate.is_symlink()
+            and candidate.suffix in embedded_suffixes
+        ),
+        key=lambda candidate: len(candidate.parts),
+        reverse=True,
+    )
+    for embedded_bundle in embedded_bundles:
+        sign_runtime_bundle(embedded_bundle, identity)
     run(
         [
             "codesign",
@@ -814,14 +863,51 @@ def patch_renderer(extracted: Path, token: str) -> None:
         )
     bundle_path = initial_bundles[0]
     bundle = bundle_path.read_text(encoding="utf-8")
-    if "function CodexMuxAccountMenu(" in bundle:
+    primary_bundles = list((webview / "assets").glob("app-primary-*.js"))
+    primary_menu_marker = "function ign(e){let t=(0,Fq.c)(223),"
+    primary_menu_bundles = [
+        path
+        for path in primary_bundles
+        if primary_menu_marker in path.read_text(encoding="utf-8")
+    ]
+    build_7746 = len(primary_menu_bundles) == 1
+    if len(primary_menu_bundles) > 1:
+        raise RuntimeError(
+            "expected at most one ChatGPT primary renderer menu bundle, "
+            f"found {len(primary_menu_bundles)}"
+        )
+    menu_bundle_path = primary_menu_bundles[0] if build_7746 else bundle_path
+    menu_bundle = (
+        menu_bundle_path.read_text(encoding="utf-8") if build_7746 else bundle
+    )
+    if "function CodexMuxAccountMenu(" in bundle or (
+        build_7746 and "function CodexMuxAccountMenu(" in menu_bundle
+    ):
         raise RuntimeError("source app already contains the Codex multiplexer menu")
 
     component = (PROJECT_ROOT / "ui" / "account-menu.js").read_text(encoding="utf-8")
     component = component.replace("__CODEX_MUX_CONTROL_PORT__", str(CONTROL_PORT))
     component = component.replace("__CODEX_MUX_CONTROL_TOKEN__", token)
     build_6662 = "function Icl(e){let t=(0,Vcl.c)(248)," in bundle
-    if build_6662:
+    if build_7746:
+        component = replace_javascript_identifiers(
+            component,
+            {
+                "e7": "Iq",
+                "kXc": "lgn",
+                "Lo": "DO",
+                "Q": "_S",
+                "BW": "ru",
+                "QLs": "jG",
+                "_H": "fa",
+                "S2": "eD",
+                "CH": "Oo",
+                "jLa": "jB",
+                "lt": "Su",
+            },
+        )
+        component_anchor = primary_menu_marker
+    elif build_6662:
         component = replace_javascript_identifiers(
             component,
             {
@@ -840,32 +926,70 @@ def patch_renderer(extracted: Path, token: str) -> None:
         component_anchor = "function Icl(e){let t=(0,Vcl.c)(248),"
     else:
         component_anchor = "function wXc({sidebarFooter:e,triggerButton:t})"
-    if bundle.count(component_anchor) != 1:
+    component_bundle = menu_bundle if build_7746 else bundle
+    if component_bundle.count(component_anchor) != 1:
         raise RuntimeError("could not find the native ChatGPT profile menu component")
-    bundle = bundle.replace(component_anchor, component + "\n" + component_anchor, 1)
-
-    rpc_wrapper = "J9" if build_6662 else "q9"
-    status_rpc_wrapper = "q9" if build_6662 else "K9"
-    plugin_rpc_mapping_anchors = (
-        f'"list-apps":{rpc_wrapper}((e,{{priority:t,source:n,timeoutMs:r,'
-        "trace:i,...a})=>e.sendRequest(`app/list`,a,",
-        f'"list-installed-apps":{rpc_wrapper}((e,t)=>'
-        "e.sendRequest(`app/installed`,t))",
-        f'"read-apps":{rpc_wrapper}((e,t)=>e.sendRequest(`app/read`,t))',
-        f'"login-mcp-server":{rpc_wrapper}((e,t)=>'
-        "e.sendRequest(`mcpServer/oauth/login`,t))",
-        f'"list-mcp-server-status":{status_rpc_wrapper}((e,{{priority:t,'
-        "source:n,timeoutMs:r,trace:i,...a})=>e.listMcpServers(a,",
-        "listMcpServers(e,t){let n=JSON.stringify({options:t,params:e})",
-        "let i=this.sendRequest(`mcpServerStatus/list`,e,t);",
+    component_bundle = component_bundle.replace(
+        component_anchor, component + "\n" + component_anchor, 1
     )
-    for mapping_anchor in plugin_rpc_mapping_anchors:
-        if bundle.count(mapping_anchor) != 1:
+    if build_7746:
+        menu_bundle = component_bundle
+    else:
+        bundle = component_bundle
+
+    if build_7746:
+        plugin_rpc_literals = (
+            ("sendRequest(`app/list`", 2),
+            ("sendRequest(`app/installed`", 2),
+            ("sendRequest(`app/read`", 2),
+            ("sendRequest(`mcpServer/oauth/login`", 1),
+            ("sendRequest(`mcpServerStatus/list`", 1),
+        )
+        if any(
+            bundle.count(literal) != expected
+            for literal, expected in plugin_rpc_literals
+        ):
             raise RuntimeError(
                 "could not verify the native Plugins request-to-RPC mapping"
             )
+        app_server_request_anchor = (
+            "async sendRequest(e,t,n){if(this.dispatchMessage==null)throw Error("
+            "`AppServerRequestClient is missing a message dispatcher`);"
+            "return e===`config/read`?this.sendConfigReadRequest(t,n):"
+            "this.enqueueRequest(e,t,e===`plugin/list`&&n?.timeoutMs==null?"
+            "{...n,timeoutMs:vCn}:n)}"
+        )
+        app_server_request_replacement = (
+            "async sendRequest(e,t,n){if(this.dispatchMessage==null)throw Error("
+            "`AppServerRequestClient is missing a message dispatcher`);"
+            "let r=globalThis.codexMuxScopePluginRequest?.(e,t)??t;"
+            "return e===`config/read`?this.sendConfigReadRequest(r,n):"
+            "this.enqueueRequest(e,r,e===`plugin/list`&&n?.timeoutMs==null?"
+            "{...n,timeoutMs:vCn}:n)}"
+        )
+    else:
+        rpc_wrapper = "J9" if build_6662 else "q9"
+        status_rpc_wrapper = "q9" if build_6662 else "K9"
+        plugin_rpc_mapping_anchors = (
+            f'"list-apps":{rpc_wrapper}((e,{{priority:t,source:n,timeoutMs:r,'
+            "trace:i,...a})=>e.sendRequest(`app/list`,a,",
+            f'"list-installed-apps":{rpc_wrapper}((e,t)=>'
+            "e.sendRequest(`app/installed`,t))",
+            f'"read-apps":{rpc_wrapper}((e,t)=>e.sendRequest(`app/read`,t))',
+            f'"login-mcp-server":{rpc_wrapper}((e,t)=>'
+            "e.sendRequest(`mcpServer/oauth/login`,t))",
+            f'"list-mcp-server-status":{status_rpc_wrapper}((e,{{priority:t,'
+            "source:n,timeoutMs:r,trace:i,...a})=>e.listMcpServers(a,",
+            "listMcpServers(e,t){let n=JSON.stringify({options:t,params:e})",
+            "let i=this.sendRequest(`mcpServerStatus/list`,e,t);",
+        )
+        for mapping_anchor in plugin_rpc_mapping_anchors:
+            if bundle.count(mapping_anchor) != 1:
+                raise RuntimeError(
+                    "could not verify the native Plugins request-to-RPC mapping"
+                )
 
-    if build_6662:
+    if build_6662 and not build_7746:
         app_server_request_anchor = (
             "function Bp(e,t,n){return n==null?N8e.sendRequest(e,t):"
             "N8e.sendRequest(e,t,n)}"
@@ -874,7 +998,7 @@ def patch_renderer(extracted: Path, token: str) -> None:
             "function Bp(e,t,n){let r=codexMuxScopePluginRequest(e,t);"
             "return n==null?N8e.sendRequest(e,r):N8e.sendRequest(e,r,n)}"
         )
-    else:
+    elif not build_7746:
         app_server_request_anchor = (
             "function gm(e,t,n){return n==null?h6e.sendRequest(e,t):"
             "h6e.sendRequest(e,t,n)}"
@@ -891,47 +1015,84 @@ def patch_renderer(extracted: Path, token: str) -> None:
         1,
     )
 
-    usage_query_pattern = re.compile(
-        r"queryKey:\[`rate-limit-status`\],queryFn:async\(\)=>\{try\{return await "
-        r"(?P<client>[A-Za-z_$][A-Za-z0-9_$]*)\.safeGet\(`/wham/usage`\)\}"
-    )
-    usage_query_matches = list(usage_query_pattern.finditer(bundle))
-    if len(usage_query_matches) != 1:
-        raise RuntimeError("could not find the native rate-limit status query")
-    usage_query = usage_query_matches[0]
-    bundle = (
-        bundle[: usage_query.start()]
-        + "queryKey:[`rate-limit-status`],queryFn:async()=>{try{return await "
-        "codexMuxFilterUsageStatus(await "
-        f"{usage_query.group('client')}.safeGet(`/wham/usage`))}}"
-        + bundle[usage_query.end() :]
-    )
+    if build_7746:
+        usage_query_anchor = "return _lr(t,o),o"
+        if bundle.count(usage_query_anchor) != 1:
+            raise RuntimeError("could not find the native rate-limit status query")
+        bundle = bundle.replace(
+            usage_query_anchor,
+            "o=await globalThis.codexMuxFilterUsageStatus?.(o)??o;"
+            "return _lr(t,o),o",
+            1,
+        )
+    else:
+        usage_query_pattern = re.compile(
+            r"queryKey:\[`rate-limit-status`\],queryFn:async\(\)=>\{try\{return await "
+            r"(?P<client>[A-Za-z_$][A-Za-z0-9_$]*)\.safeGet\(`/wham/usage`\)\}"
+        )
+        usage_query_matches = list(usage_query_pattern.finditer(bundle))
+        if len(usage_query_matches) != 1:
+            raise RuntimeError("could not find the native rate-limit status query")
+        usage_query = usage_query_matches[0]
+        bundle = (
+            bundle[: usage_query.start()]
+            + "queryKey:[`rate-limit-status`],queryFn:async()=>{try{return await "
+            "codexMuxFilterUsageStatus(await "
+            f"{usage_query.group('client')}.safeGet(`/wham/usage`))}}"
+            + bundle[usage_query.end() :]
+        )
 
     profile_query_anchor = (
         "let e=await c_.safeGet(`/wham/profiles/me`)"
         if build_6662
-        else "let e=await T_.safeGet(`/wham/profiles/me`)"
+        else (
+            "async function Uzs(){let e=await AO.safeGet(`/wham/profiles/me`)"
+            if build_7746
+            else "let e=await T_.safeGet(`/wham/profiles/me`)"
+        )
     )
     if bundle.count(profile_query_anchor) != 1:
         raise RuntimeError("could not find the native profile stats request")
-    bundle = bundle.replace(
-        profile_query_anchor,
-        "let e=await codexMuxProfileData("
-        "globalThis.__codexMuxSelectedProfileAccountId??null)",
-        1,
+    profile_query_replacement = (
+        "async function Uzs(){let e=globalThis.codexMuxProfileData?await "
+        "globalThis.codexMuxProfileData("
+        "globalThis.__codexMuxSelectedProfileAccountId??null):"
+        "await AO.safeGet(`/wham/profiles/me`)"
+        if build_7746
+        else "let e=await codexMuxProfileData("
+        "globalThis.__codexMuxSelectedProfileAccountId??null)"
     )
+    bundle = bundle.replace(profile_query_anchor, profile_query_replacement, 1)
 
-    native_usage_modal_name = "E$s" if build_6662 else "QLs"
+    native_bundle = menu_bundle if build_7746 else bundle
+    native_usage_modal_name = (
+        "jG" if build_7746 else ("E$s" if build_6662 else "QLs")
+    )
     native_usage_modal_anchor = f"function {native_usage_modal_name}(e){{"
-    if bundle.count(native_usage_modal_anchor) != 1:
+    if native_bundle.count(native_usage_modal_anchor) != 1:
         raise RuntimeError("could not find the native Usage modal component")
-    bundle = bundle.replace(
+    native_bundle = native_bundle.replace(
         native_usage_modal_anchor,
         f"function {native_usage_modal_name}(e){{CodexMuxUseResetAccountState();",
         1,
     )
 
-    if build_6662:
+    if build_7746:
+        reset_query_anchor = (
+            "function l2i(){let e=(0,RK.c)(1);HR(),lb(null);let t;return "
+            "e[0]===Symbol.for(`react.memo_cache_sentinel`)?"
+            "(t={queryKey:[`rate-limit-reset-credits`],queryFn:d2i,select:u2i,"
+            "refetchInterval:gD.ONE_MINUTE,staleTime:gD.FIVE_SECONDS},e[0]=t):"
+            "t=e[0],vb(t)}"
+        )
+        reset_query_replacement = (
+            "function l2i(){HR(),lb(null);let e=window.__codexMuxResetAccountId;"
+            "return vb({queryKey:[`rate-limit-reset-credits`,e??`primary`],"
+            "queryFn:e&&globalThis.codexMuxRateLimitResets?"
+            "()=>globalThis.codexMuxRateLimitResets(e):d2i,select:u2i,"
+            "refetchInterval:gD.ONE_MINUTE,staleTime:gD.FIVE_SECONDS})}"
+        )
+    elif build_6662:
         reset_query_anchor = (
             "function Ooi(){let e=(0,SI.c)(1),t;return "
             "e[0]===Symbol.for(`react.memo_cache_sentinel`)?"
@@ -967,7 +1128,27 @@ def patch_renderer(extracted: Path, token: str) -> None:
         1,
     )
 
-    if build_6662:
+    if build_7746:
+        reset_mutation_anchor = (
+            "function f2i(){let e=(0,RK.c)(3),t=mb(),n=mD(),r;return "
+            "e[0]!==n||e[1]!==t?(r={mutationFn:p2i,onSuccess:(e,r)=>{"
+            "let{creditId:i}=r,a=e.code;if(a===`reset`||a===`already_redeemed`){"
+            "let n=e.code===`reset`?e.credit?.id??i:i;"
+            "t.setQueryData([`rate-limit-reset-credits`],e=>Y1i(e,a,n))}"
+            "Promise.all([n([`rate-limit-status`]),n([`rate-limit-reset-credits`])])}},"
+            "e[0]=n,e[1]=t,e[2]=r):r=e[2],xb(r)}"
+        )
+        reset_mutation_replacement = (
+            "function f2i(){let e=mb(),t=mD(),n=window.__codexMuxResetAccountId,"
+            "r=[`rate-limit-reset-credits`,n??`primary`];return xb({"
+            "mutationFn:n&&globalThis.codexMuxConsumeRateLimitReset?"
+            "i=>globalThis.codexMuxConsumeRateLimitReset(n,i):p2i,"
+            "onSuccess:(n,i)=>{let{creditId:a}=i,o=n.code;"
+            "if(o===`reset`||o===`already_redeemed`){let t=o===`reset`?"
+            "n.credit?.id??a:a;e.setQueryData(r,e=>Y1i(e,o,t))}"
+            "Promise.all([t([`rate-limit-status`]),t(r)])}})}"
+        )
+    elif build_6662:
         reset_mutation_anchor = (
             "function Aoi(){let e=(0,SI.c)(3),t=ct(),n=Uw(),r;return "
             "e[0]!==n||e[1]!==t?(r={mutationFn:joi,onSuccess:(e,r)=>{"
@@ -1014,15 +1195,24 @@ def patch_renderer(extracted: Path, token: str) -> None:
     )
 
     selected_usage_anchor = "let y=v;if(g!=null){"
-    if bundle.count(selected_usage_anchor) != 1:
+    if native_bundle.count(selected_usage_anchor) != 1:
         raise RuntimeError("could not find the native usage-window selection")
-    bundle = bundle.replace(
+    native_bundle = native_bundle.replace(
         selected_usage_anchor,
         "let y=window.__codexMuxSelectedUsageWindows??v;if(g!=null){",
         1,
     )
 
-    if build_6662:
+    if build_7746:
+        usage_header_anchor = (
+            "let ge;t[46]===me?ge=t[47]:"
+            "(ge=(0,AG.jsxs)(Gv,{children:[me,he]}),t[46]=me,t[47]=ge);"
+        )
+        usage_header_replacement = (
+            "let ge=(0,AG.jsxs)(Gv,{children:[me,he,"
+            "window.__codexMuxResetAccountSelector??null]});"
+        )
+    elif build_6662:
         usage_header_anchor = (
             "let _e;t[46]===he?_e=t[47]:"
             "(_e=(0,I0.jsxs)(WL,{children:[he,ge]}),t[46]=he,t[47]=_e);"
@@ -1040,28 +1230,42 @@ def patch_renderer(extracted: Path, token: str) -> None:
             "let ve=(0,k2.jsxs)(LL,{children:[ge,_e,"
             "window.__codexMuxResetAccountSelector??null]});"
         )
-    if bundle.count(usage_header_anchor) != 1:
+    if native_bundle.count(usage_header_anchor) != 1:
         raise RuntimeError("could not find the native Usage sheet header")
-    bundle = bundle.replace(
+    native_bundle = native_bundle.replace(
         usage_header_anchor,
         usage_header_replacement,
         1,
     )
 
-    usage_anchor = "usageItems:Ct" if build_6662 else "usageItems:Ge"
-    if bundle.count(usage_anchor) != 1:
+    usage_anchor = (
+        "usageItems:Tt"
+        if build_7746
+        else ("usageItems:Ct" if build_6662 else "usageItems:Ge")
+    )
+    if native_bundle.count(usage_anchor) != 1:
         raise RuntimeError("could not find the native ChatGPT usage menu slot")
-    bundle = bundle.replace(
+    native_bundle = native_bundle.replace(
         usage_anchor,
         (
-            "usageItems:(0,$5.jsx)(CodexMuxAccountMenu,{})"
-            if build_6662
-            else "usageItems:(0,e7.jsx)(CodexMuxAccountMenu,{})"
+            "usageItems:(0,Iq.jsx)(CodexMuxAccountMenu,{})"
+            if build_7746
+            else (
+                "usageItems:(0,$5.jsx)(CodexMuxAccountMenu,{})"
+                if build_6662
+                else "usageItems:(0,e7.jsx)(CodexMuxAccountMenu,{})"
+            )
         ),
         1,
     )
 
-    if build_6662:
+    if build_7746:
+        open_change_anchors = (
+            "triggerButton:kt,onOpenChange:c,children:[F,null]",
+            "open:s,onOpenChange:c,contentWidth:`panel`,triggerButton:kt",
+        )
+        open_change_name = "c"
+    elif build_6662:
         open_change_anchors = (
             "triggerButton:Dt,onOpenChange:l,children:P",
             "open:s,onOpenChange:l,contentWidth:`panel`,triggerButton:Dt",
@@ -1074,9 +1278,9 @@ def patch_renderer(extracted: Path, token: str) -> None:
         )
         open_change_name = "o"
     for anchor in open_change_anchors:
-        if bundle.count(anchor) != 1:
+        if native_bundle.count(anchor) != 1:
             raise RuntimeError("could not find a native profile menu open-state hook")
-        bundle = bundle.replace(
+        native_bundle = native_bundle.replace(
             anchor,
             anchor.replace(
                 f"onOpenChange:{open_change_name}",
@@ -1092,23 +1296,56 @@ def patch_renderer(extracted: Path, token: str) -> None:
         "defaultMessage:`You’ve reached your usage limit`",
     )
     for depleted_anchor in depleted_alert_anchors:
-        if bundle.count(depleted_anchor) != 1:
+        if native_bundle.count(depleted_anchor) != 1:
             raise RuntimeError("could not find a native subscription depletion alert")
-        bundle = bundle.replace(
+        native_bundle = native_bundle.replace(
             depleted_anchor,
             "defaultMessage:`All connected subscriptions are depleted`",
             1,
         )
+    if build_7746:
+        menu_bundle = native_bundle
+    else:
+        bundle = native_bundle
     bundle_path.write_text(bundle, encoding="utf-8")
+    if build_7746:
+        menu_bundle_path.write_text(menu_bundle, encoding="utf-8")
 
-    profile_bundles = list((webview / "assets").glob("profile-*.js"))
+    all_profile_bundles = list((webview / "assets").glob("profile-*.js"))
+    profile_bundles = (
+        [
+            path
+            for path in all_profile_bundles
+            if "avatar:(0,$.jsxs)($.Fragment,{children:["
+            "(0,$.jsxs)(`label`,{\"aria-disabled\":L.isPending"
+            in path.read_text(encoding="utf-8")
+        ]
+        if build_7746
+        else all_profile_bundles
+    )
     if len(profile_bundles) != 1:
         raise RuntimeError(
             f"expected one native Profile settings bundle, found {len(profile_bundles)}"
         )
     profile_bundle_path = profile_bundles[0]
     profile_bundle = profile_bundle_path.read_text(encoding="utf-8")
-    if build_6662:
+    if build_7746:
+        profile_avatar_anchor = (
+            "avatar:(0,$.jsxs)($.Fragment,{children:["
+            "(0,$.jsxs)(`label`,{\"aria-disabled\":L.isPending,"
+            "className:re(`group relative flex size-20 rounded-full outline-none "
+            "focus-within:ring-1 focus-within:ring-ring`,"
+        )
+        profile_avatar_replacement = (
+            "avatar:(0,$.jsxs)($.Fragment,{children:["
+            "globalThis.CodexMuxProfileAvatarStack?.("
+            "{onSelect:()=>j.refetch()})??null,"
+            "(0,$.jsxs)(`label`,{\"aria-disabled\":L.isPending,"
+            "className:re(globalThis.CodexMuxProfileAvatarStack?`hidden`:"
+            "`group relative flex size-20 rounded-full outline-none "
+            "focus-within:ring-1 focus-within:ring-ring`,"
+        )
+    elif build_6662:
         profile_avatar_anchor = (
             "avatar:(0,$.jsxs)($.Fragment,{children:["
             "(0,$.jsxs)(`label`,{\"aria-disabled\":z.isPending,"
@@ -1145,10 +1382,15 @@ def patch_renderer(extracted: Path, token: str) -> None:
     )
 
     profile_name_anchor = (
-        "displayName:Ze??(0,$.jsx)(o,{id:`profile.nameFallback`,"
+        "displayName:Re??(0,$.jsx)(J,{id:`profile.nameFallback`,"
         "defaultMessage:`ChatGPT user`,description:`Fallback profile display name`})"
-        if build_6662
-        else "className:`flex w-full justify-center`"
+        if build_7746
+        else (
+            "displayName:Ze??(0,$.jsx)(o,{id:`profile.nameFallback`,"
+            "defaultMessage:`ChatGPT user`,description:`Fallback profile display name`})"
+            if build_6662
+            else "className:`flex w-full justify-center`"
+        )
     )
     if profile_bundle.count(profile_name_anchor) != 1:
         raise RuntimeError("could not find the native Profile display name")
@@ -1156,38 +1398,60 @@ def patch_renderer(extracted: Path, token: str) -> None:
         profile_name_anchor,
         (
             "displayName:globalThis.__codexMuxSelectedProfileAccountId?"
-            "(Ze??(0,$.jsx)(o,{id:`profile.nameFallback`,"
+            "(Re??(0,$.jsx)(J,{id:`profile.nameFallback`,"
             "defaultMessage:`ChatGPT user`,"
             "description:`Fallback profile display name`})):null"
-            if build_6662
-            else "className:globalThis.__codexMuxSelectedProfileAccountId&&"
-            "!A.isFetching?`flex w-full justify-center`:`hidden`"
+            if build_7746
+            else (
+                "displayName:globalThis.__codexMuxSelectedProfileAccountId?"
+                "(Ze??(0,$.jsx)(o,{id:`profile.nameFallback`,"
+                "defaultMessage:`ChatGPT user`,"
+                "description:`Fallback profile display name`})):null"
+                if build_6662
+                else "className:globalThis.__codexMuxSelectedProfileAccountId&&"
+                "!A.isFetching?`flex w-full justify-center`:`hidden`"
+            )
         ),
         1,
     )
     profile_identity_anchor = (
-        "username:Ke==null?null:(0,$.jsx)(o,{id:`profile.usernameValue`,"
+        "username:Ie==null?null:(0,$.jsx)(J,{id:`profile.usernameValue`,"
         "defaultMessage:`@{username}`,"
         "description:`Profile username shown with an at-sign prefix`,"
-        "values:{username:Ke}})"
-        if build_6662
-        else "className:`mt-1 flex min-h-7 items-center gap-1.5 text-base leading-5 "
-        "font-normal text-token-text-tertiary`"
+        "values:{username:Ie}})"
+        if build_7746
+        else (
+            "username:Ke==null?null:(0,$.jsx)(o,{id:`profile.usernameValue`,"
+            "defaultMessage:`@{username}`,"
+            "description:`Profile username shown with an at-sign prefix`,"
+            "values:{username:Ke}})"
+            if build_6662
+            else "className:`mt-1 flex min-h-7 items-center gap-1.5 text-base leading-5 "
+            "font-normal text-token-text-tertiary`"
+        )
     )
     if profile_bundle.count(profile_identity_anchor) != 1:
         raise RuntimeError("could not find the native Profile username and plan badge")
     profile_bundle = profile_bundle.replace(
         profile_identity_anchor,
         (
-            "username:globalThis.__codexMuxSelectedProfileAccountId&&Ke!=null?"
-            "(0,$.jsx)(o,{id:`profile.usernameValue`,"
+            "username:globalThis.__codexMuxSelectedProfileAccountId&&Ie!=null?"
+            "(0,$.jsx)(J,{id:`profile.usernameValue`,"
             "defaultMessage:`@{username}`,"
             "description:`Profile username shown with an at-sign prefix`,"
-            "values:{username:Ke}}):null"
-            if build_6662
-            else "className:globalThis.__codexMuxSelectedProfileAccountId&&"
-            "!A.isFetching?`mt-1 flex min-h-7 items-center gap-1.5 text-base "
-            "leading-5 font-normal text-token-text-tertiary`:`hidden`"
+            "values:{username:Ie}}):null"
+            if build_7746
+            else (
+                "username:globalThis.__codexMuxSelectedProfileAccountId&&Ke!=null?"
+                "(0,$.jsx)(o,{id:`profile.usernameValue`,"
+                "defaultMessage:`@{username}`,"
+                "description:`Profile username shown with an at-sign prefix`,"
+                "values:{username:Ke}}):null"
+                if build_6662
+                else "className:globalThis.__codexMuxSelectedProfileAccountId&&"
+                "!A.isFetching?`mt-1 flex min-h-7 items-center gap-1.5 text-base "
+                "leading-5 font-normal text-token-text-tertiary`:`hidden`"
+            )
         ),
         1,
     )
@@ -1225,9 +1489,13 @@ def patch_renderer(extracted: Path, token: str) -> None:
     plugin_bundle_path.write_text(plugin_bundle, encoding="utf-8")
 
     thread_component_anchor = (
-        "function bE(){let e=(0,SE.c)(1)"
-        if build_6662
-        else "function bE(){let e=(0,wE.c)(57)"
+        "function uT(e){let t=(0,pT.c)(43),"
+        if build_7746
+        else (
+            "function bE(){let e=(0,SE.c)(1)"
+            if build_6662
+            else "function bE(){let e=(0,wE.c)(57)"
+        )
     )
     thread_bundles = [
         path
@@ -1247,7 +1515,19 @@ def patch_renderer(extracted: Path, token: str) -> None:
         "__CODEX_MUX_CONTROL_PORT__", str(CONTROL_PORT)
     )
     thread_component = thread_component.replace("__CODEX_MUX_CONTROL_TOKEN__", token)
-    if build_6662:
+    if build_7746:
+        thread_component = replace_javascript_identifiers(
+            thread_component,
+            {
+                "$n": "zd",
+                "sr": "Gi",
+                "TE": "nT",
+                "zE": "mT",
+                "K": "Q",
+            },
+        )
+        summary_component = "mT"
+    elif build_6662:
         thread_component = replace_javascript_identifiers(
             thread_component,
             {
@@ -1268,14 +1548,25 @@ def patch_renderer(extracted: Path, token: str) -> None:
         thread_component + "\n" + thread_component_anchor,
         1,
     )
-    summary_children_anchor = "children:[c,l,u,d,f,p,m,h,g,_,v,y,b,x]"
+    summary_children_anchor = (
+        "children:[d,f,p,m,h,g,_,v,y,b,x,S,C,w,T,E,D]"
+        if build_7746
+        else "children:[c,l,u,d,f,p,m,h,g,_,v,y,b,x]"
+    )
     if thread_bundle.count(summary_children_anchor) != 1:
         raise RuntimeError("could not find the native thread summary section list")
+    summary_children_replacement = (
+        "children:[d,f,p,m,h,g,_,v,y,b,x,S,(0,"
+        f"{summary_component}.jsx)(CodexMuxThreadSubscription,{{}}),"
+        "C,w,T,E,D]"
+        if build_7746
+        else "children:[c,l,u,d,f,(0,"
+        f"{summary_component}.jsx)(CodexMuxThreadSubscription,{{}}),"
+        "p,m,h,g,_,v,y,b,x]"
+    )
     thread_bundle = thread_bundle.replace(
         summary_children_anchor,
-        "children:[c,l,u,d,f,(0,"
-        f"{summary_component}.jsx)(CodexMuxThreadSubscription,{{}}),"
-        "p,m,h,g,_,v,y,b,x]",
+        summary_children_replacement,
         1,
     )
     thread_bundle_path.write_text(thread_bundle, encoding="utf-8")
@@ -1349,7 +1640,7 @@ def patch_desktop_profile(
     # The copied app must never replace itself with an unpatched official update.
     updater_pattern = re.compile(
         r"await [A-Za-z_$][\w$]*\.initialize\(\);"
-        r"(?=try\{let\{runMainAppStartup:)"
+        r"(?=(?:try\{)?let\{runMainAppStartup:)"
     )
     bootstrap, updater_replacements = updater_pattern.subn("", bootstrap, count=1)
     if updater_replacements != 1:

--- a/ui/account-menu.js
+++ b/ui/account-menu.js
@@ -18,6 +18,36 @@ async function codexMuxRequest(path, options = {}) {
   return body;
 }
 
+const CODEX_MUX_ACCOUNTS_CACHE_KEY = "codex-mux.accounts";
+
+function codexMuxCachedAccounts() {
+  if (Array.isArray(globalThis.__codexMuxAccounts)) {
+    return globalThis.__codexMuxAccounts;
+  }
+  try {
+    const stored = JSON.parse(localStorage.getItem(CODEX_MUX_ACCOUNTS_CACHE_KEY));
+    if (Array.isArray(stored)) {
+      globalThis.__codexMuxAccounts = stored;
+      return stored;
+    }
+  } catch {}
+  return [];
+}
+
+function codexMuxRememberAccounts(accounts) {
+  globalThis.__codexMuxAccounts = accounts;
+  try {
+    localStorage.setItem(CODEX_MUX_ACCOUNTS_CACHE_KEY, JSON.stringify(accounts));
+  } catch {}
+}
+
+async function codexMuxFetchAccounts() {
+  const result = await codexMuxRequest("/accounts");
+  const accounts = result.accounts || [];
+  codexMuxRememberAccounts(accounts);
+  return accounts;
+}
+
 const CODEX_MUX_ACCOUNT_SCOPED_PLUGIN_METHODS = new Set([
   "list-apps",
   "list-installed-apps",
@@ -150,7 +180,7 @@ function CodexMuxUsageModal({
 }
 
 function CodexMuxUseResetAccountState() {
-  const cachedAccounts = (globalThis.__codexMuxConnectedAccounts || []).filter(
+  const cachedAccounts = codexMuxCachedAccounts().filter(
     (account) => account.connected && account.enabled,
   );
   const [accounts, setAccounts] = kXc.useState(cachedAccounts);
@@ -159,8 +189,7 @@ function CodexMuxUseResetAccountState() {
   const [loading, setLoading] = kXc.useState(cachedAccounts.length === 0);
 
   const loadAccounts = kXc.useCallback(async () => {
-    const result = await codexMuxRequest("/accounts");
-    const connected = (result.accounts || []).filter(
+    const connected = (await codexMuxFetchAccounts()).filter(
       (account) => account.connected && account.enabled,
     );
     setAccounts(connected);
@@ -293,8 +322,10 @@ function CodexMuxResetAccountSelector({
 
 function CodexMuxAccountMenu() {
   const modalScope = Lo(Q);
-  const [accounts, setAccounts] = kXc.useState([]);
-  const [loading, setLoading] = kXc.useState(true);
+  const [accounts, setAccounts] = kXc.useState(codexMuxCachedAccounts);
+  const [loading, setLoading] = kXc.useState(
+    () => !codexMuxCachedAccounts().some((account) => account.connected),
+  );
   const [busy, setBusy] = kXc.useState(false);
   const [error, setError] = kXc.useState("");
   const [login, setLogin] = kXc.useState(null);
@@ -303,11 +334,7 @@ function CodexMuxAccountMenu() {
 
   const refresh = kXc.useCallback(async () => {
     try {
-      const result = await codexMuxRequest("/accounts");
-      const nextAccounts = result.accounts || [];
-      globalThis.__codexMuxConnectedAccounts = nextAccounts.filter(
-        (account) => account.connected && account.enabled,
-      );
+      const nextAccounts = await codexMuxFetchAccounts();
       setAccounts(nextAccounts);
       setError("");
       if (nextAccounts.some((account) => account.connected)) setLoading(false);
@@ -746,17 +773,20 @@ function CodexMuxProfileAvatarStack({ onSelect }) {
 }
 
 function CodexMuxPluginScope() {
-  const [accounts, setAccounts] = kXc.useState([]);
+  const cachedAccounts = codexMuxCachedAccounts().filter(
+    (account) => account.connected && account.enabled,
+  );
+  const [accounts, setAccounts] = kXc.useState(cachedAccounts);
   const [selectedId, setSelectedId] = kXc.useState("primary");
-  const [loading, setLoading] = kXc.useState(true);
+  const [loading, setLoading] = kXc.useState(cachedAccounts.length === 0);
   const queryClient = lt();
   kXc.useEffect(() => {
     let live = true;
-    codexMuxRequest("/accounts")
-      .then((result) => {
+    codexMuxFetchAccounts()
+      .then((connectedAccounts) => {
         if (!live) return;
         setAccounts(
-          (result.accounts || []).filter(
+          connectedAccounts.filter(
             (account) => account.connected && account.enabled,
           ),
         );

--- a/ui/account-menu.js
+++ b/ui/account-menu.js
@@ -48,6 +48,76 @@ async function codexMuxProfileData(accountId = null) {
   return result.profile;
 }
 
+// The renderer polls `/wham/usage` over HTTP for the Primary account only, so
+// its usage banners, sidebar alert, and reset prompts describe one account
+// while the multiplexer routes across the pool. Replace the rate-limit
+// windows with the pooled view (mean usage, earliest reset) and clear the
+// limit-reached fields while any connected subscription still has weekly
+// capacity. A fully depleted pool keeps the native limit-reached response.
+async function codexMuxFilterUsageStatus(status) {
+  if (status == null || typeof status !== "object") return status;
+  let accounts;
+  try {
+    accounts = (await codexMuxRequest("/accounts")).accounts || [];
+  } catch {
+    return status;
+  }
+  const pool = accounts.filter(
+    (account) =>
+      account.enabled &&
+      account.connected &&
+      (!account.authType || account.authType === "chatgpt"),
+  );
+  if (pool.length < 2) return status;
+  const poolHasCapacity = pool.some((account) => {
+    const weekly = codexMuxWeeklyWindow(account.rateLimits);
+    return weekly == null || weekly.usedPercent < 100;
+  });
+  const rateLimit = status.rate_limit;
+  const pooledRateLimit =
+    rateLimit == null
+      ? rateLimit
+      : {
+          ...rateLimit,
+          primary_window: codexMuxPooledUsageWindow(
+            rateLimit.primary_window,
+            pool.map((account) => account.rateLimits?.primary),
+          ),
+          secondary_window: codexMuxPooledUsageWindow(
+            rateLimit.secondary_window,
+            pool.map((account) => account.rateLimits?.secondary),
+          ),
+        };
+  if (!poolHasCapacity) return { ...status, rate_limit: pooledRateLimit };
+  return {
+    ...status,
+    rate_limit_upsell: null,
+    rate_limit_reached_type: null,
+    rate_limit:
+      pooledRateLimit == null
+        ? pooledRateLimit
+        : { ...pooledRateLimit, allowed: true, limit_reached: false },
+  };
+}
+
+function codexMuxPooledUsageWindow(window, accountWindows) {
+  if (window == null) return window;
+  const windows = accountWindows.filter(Boolean);
+  if (windows.length === 0) return window;
+  const usedPercent =
+    windows.reduce((total, entry) => total + entry.usedPercent, 0) /
+    windows.length;
+  const resets = windows
+    .map((entry) => entry.resetsAt)
+    .filter((value) => value != null);
+  const resetsAt = resets.length === 0 ? null : Math.min(...resets);
+  return {
+    ...window,
+    used_percent: usedPercent,
+    reset_at: resetsAt ?? window.reset_at,
+  };
+}
+
 async function codexMuxRateLimitResets(accountId) {
   return codexMuxRequest(
     `/accounts/${encodeURIComponent(accountId)}/rate-limit-resets`,

--- a/ui/account-menu.js
+++ b/ui/account-menu.js
@@ -1,12 +1,7 @@
 const CODEX_MUX_API = "http://127.0.0.1:__CODEX_MUX_CONTROL_PORT__/v1";
 const CODEX_MUX_TOKEN = "__CODEX_MUX_CONTROL_TOKEN__";
-let codexMuxLoginActive = false;
-
 function CodexMuxProfileMenuOpenChange(setOpen) {
-  return (nextOpen) => {
-    if (!nextOpen && codexMuxLoginActive) return;
-    setOpen(nextOpen);
-  };
+  return (nextOpen) => setOpen(nextOpen);
 }
 
 async function codexMuxRequest(path, options = {}) {
@@ -264,7 +259,6 @@ function CodexMuxAccountMenu() {
           payload.type === "account-updated" &&
           payload.accountId === loginAccountId
         ) {
-          codexMuxLoginActive = false;
           setLogin(null);
         }
         if (payload.type === "account-updated") refresh();
@@ -287,7 +281,6 @@ function CodexMuxAccountMenu() {
     if (!login) return;
     const allowEscapeDismissal = (event) => {
       if (event.key !== "Escape") return;
-      codexMuxLoginActive = false;
       setLogin(null);
     };
     window.addEventListener("keydown", allowEscapeDismissal, true);
@@ -325,7 +318,6 @@ function CodexMuxAccountMenu() {
       const pendingLogin = result.login
         ? { ...result.login, accountId: created.account.id }
         : null;
-      codexMuxLoginActive = pendingLogin != null;
       setCodeCopied(false);
       setLogin(pendingLogin);
       await refresh();

--- a/ui/account-menu.js
+++ b/ui/account-menu.js
@@ -154,6 +154,21 @@ async function codexMuxRateLimitResets(accountId) {
   );
 }
 
+function codexMuxAvailableResetCount(resets) {
+  if (resets == null || typeof resets !== "object") return null;
+  const available = resets.available_count;
+  if (available != null) {
+    return Number.isSafeInteger(available) && available >= 0 ? available : null;
+  }
+  const applicable = resets.applicable_available_count;
+  if (applicable != null) {
+    return Number.isSafeInteger(applicable) && applicable >= 0
+      ? applicable
+      : null;
+  }
+  return null;
+}
+
 async function codexMuxConsumeRateLimitReset(accountId, input) {
   return codexMuxRequest(
     `/accounts/${encodeURIComponent(accountId)}/rate-limit-resets/consume`,
@@ -184,7 +199,14 @@ function CodexMuxUseResetAccountState() {
     (account) => account.connected && account.enabled,
   );
   const [accounts, setAccounts] = kXc.useState(cachedAccounts);
-  const [selectedId, setSelectedId] = kXc.useState("primary");
+  const [selectedId, setSelectedId] = kXc.useState(
+    () =>
+      cachedAccounts.find(
+        (account) => account.id === globalThis.__codexMuxResetAccountId,
+      )?.id ||
+      cachedAccounts[0]?.id ||
+      null,
+  );
   const [resetCounts, setResetCounts] = kXc.useState({});
   const [loading, setLoading] = kXc.useState(cachedAccounts.length === 0);
 
@@ -193,17 +215,23 @@ function CodexMuxUseResetAccountState() {
       (account) => account.connected && account.enabled,
     );
     setAccounts(connected);
-    setSelectedId((current) =>
-      connected.some((account) => account.id === current)
+    setSelectedId((current) => {
+      const next = connected.some((account) => account.id === current)
         ? current
-        : connected[0]?.id || "primary",
-    );
+        : connected[0]?.id || null;
+      if (next) {
+        globalThis.__codexMuxResetAccountId = next;
+      } else {
+        delete globalThis.__codexMuxResetAccountId;
+      }
+      return next;
+    });
     setLoading(false);
     const entries = await Promise.all(
       connected.map(async (account) => {
         try {
           const resets = await codexMuxRateLimitResets(account.id);
-          return [account.id, Math.max(0, resets.available_count || 0)];
+          return [account.id, codexMuxAvailableResetCount(resets)];
         } catch {
           return [account.id, null];
         }
@@ -227,8 +255,12 @@ function CodexMuxUseResetAccountState() {
 
   const selected =
     accounts.find((account) => account.id === selectedId) || accounts[0] || null;
-  const activeId = selected?.id || selectedId;
-  window.__codexMuxResetAccountId = activeId;
+  const activeId = selected?.id || null;
+  if (activeId) {
+    window.__codexMuxResetAccountId = activeId;
+  } else {
+    delete window.__codexMuxResetAccountId;
+  }
   window.__codexMuxSelectedUsageWindows = selected
     ? codexMuxUsageWindows(selected.rateLimits)
     : null;
@@ -239,7 +271,10 @@ function CodexMuxUseResetAccountState() {
       loading,
       resetCounts,
       selectedId: activeId,
-      onSelect: setSelectedId,
+      onSelect: (accountId) => {
+        window.__codexMuxResetAccountId = accountId;
+        setSelectedId(accountId);
+      },
     },
   );
 
@@ -511,6 +546,33 @@ function CodexMuxAccountMenu() {
             : account.label,
         },
         `codex-mux-account-${account.id}`,
+      ),
+    );
+  }
+
+  for (const account of accounts.filter(
+    (account) =>
+      !account.connected &&
+      typeof account.error === "string" &&
+      account.error.trim() !== "",
+  )) {
+    rows.push(
+      (0, e7.jsx)(
+        _H,
+        {
+          LeftIcon: (iconProps) =>
+            (0, e7.jsx)(CodexMuxAccountAvatar, {
+              ...iconProps,
+              imageUrl: account.profileImageUrl,
+              label: account.label,
+            }),
+          SubText: "Couldn’t refresh this subscription. Retrying automatically.",
+          tone: "danger",
+          allowWrap: true,
+          subTextAllowWrap: true,
+          children: `${account.label} · Reconnecting`,
+        },
+        `codex-mux-unavailable-${account.id}`,
       ),
     );
   }
@@ -887,7 +949,12 @@ function CodexMuxPluginScope() {
 // Export the same avatar component so both surfaces share image resolution,
 // error handling, and the initials fallback.
 globalThis.CodexMuxAccountAvatar = CodexMuxAccountAvatar;
+globalThis.codexMuxScopePluginRequest = codexMuxScopePluginRequest;
+globalThis.codexMuxFilterUsageStatus = codexMuxFilterUsageStatus;
 globalThis.codexMuxProfileData = codexMuxProfileData;
+globalThis.codexMuxRateLimitResets = codexMuxRateLimitResets;
+globalThis.codexMuxConsumeRateLimitReset = codexMuxConsumeRateLimitReset;
+globalThis.codexMuxAvailableResetCount = codexMuxAvailableResetCount;
 globalThis.CodexMuxProfileAvatarStack = (props) =>
   (0, e7.jsx)(CodexMuxProfileAvatarStack, props || {});
 globalThis.CodexMuxPluginScope = () =>

--- a/ui/account-menu.test.cjs
+++ b/ui/account-menu.test.cjs
@@ -1,0 +1,39 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+require("./account-menu.js");
+
+const availableResetCount = globalThis.codexMuxAvailableResetCount;
+
+test("reset count preserves an explicit available_count", () => {
+  assert.equal(
+    availableResetCount({
+      available_count: 0,
+      applicable_available_count: 1,
+    }),
+    0,
+  );
+  assert.equal(
+    availableResetCount({
+      available_count: 1,
+      credits: [{ status: "available" }, { status: "consumed" }],
+    }),
+    1,
+  );
+});
+
+test("reset count falls back only when available_count is absent", () => {
+  assert.equal(availableResetCount({ applicable_available_count: 1 }), 1);
+  assert.equal(
+    availableResetCount({
+      available_count: -1,
+      applicable_available_count: 1,
+    }),
+    null,
+  );
+  assert.equal(availableResetCount({ available_count: "1" }), null);
+  assert.equal(availableResetCount({ credits: [{ status: "available" }] }), null);
+  assert.equal(availableResetCount(null), null);
+});

--- a/ui/ui-test-bridge.cjs
+++ b/ui/ui-test-bridge.cjs
@@ -64,23 +64,43 @@ async function runAction(window, action, delayMs) {
   }
   if (action === "usage-select-second") {
     const selected = await window.webContents.executeJavaScript(`(() => {
-      const target=[...document.querySelectorAll('button[aria-pressed]')]
-        .find(button=>button.textContent?.includes('Subscription 2'));
+      const accountButtons=[...document.querySelectorAll('button[aria-pressed]')]
+        .filter(button=>/resets? (?:available|unavailable)/i.test(button.textContent??''));
+      const target=accountButtons[1];
       if(!target)return false;
       target.click();
       return true;
     })()`);
     if (!selected) throw new Error("Could not select a secondary reset subscription");
     const selectionState = await window.webContents.executeJavaScript(`new Promise((resolve) => {
-      const read=()=>{const target=[...document.querySelectorAll('button[aria-pressed]')]
-        .find(button=>button.textContent?.includes('Subscription 2'));
-        return {accountId:globalThis.__codexMuxResetAccountId??null,pressed:target?.getAttribute('aria-pressed')??null};};
+      const read=()=>{const buttons=[...document.querySelectorAll('button[aria-pressed]')]
+        .filter(button=>/resets? (?:available|unavailable)/i.test(button.textContent??''));
+        return {scoped:globalThis.__codexMuxResetAccountId!=null&&globalThis.__codexMuxResetAccountId!=="primary",pressed:buttons[1]?.getAttribute('aria-pressed')??null};};
       const deadline=Date.now()+4000;
-      const poll=()=>{const state=read();if(state.accountId&&state.accountId!=="primary"&&state.pressed==="true")resolve(state);else if(Date.now()>=deadline)resolve(state);else setTimeout(poll,100);};
+      const poll=()=>{const state=read();if(state.scoped&&state.pressed==="true")resolve(state);else if(Date.now()>=deadline)resolve(state);else setTimeout(poll,100);};
       poll();
     })`);
-    if (!selectionState.accountId || selectionState.accountId === "primary" || selectionState.pressed !== "true") {
+    if (!selectionState.scoped || selectionState.pressed !== "true") {
       throw new Error(`Secondary reset subscription did not remain selected: ${JSON.stringify(selectionState)}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, Math.max(delayMs, 1_500)));
+    return;
+  }
+  if (action === "usage-select-with-reset") {
+    const selectionState = await window.webContents.executeJavaScript(`new Promise((resolve) => {
+      const read=()=>{const buttons=[...document.querySelectorAll('button[aria-pressed]')]
+        .filter(button=>/resets? (?:available|unavailable)/i.test(button.textContent??''));
+        const target=buttons.find(button=>/\\b[1-9]\\d* resets? available\\b/i.test(button.textContent??''));
+        return {buttons,target,pressed:target?.getAttribute('aria-pressed')??null};};
+      let state=read();
+      if(!state.target){resolve({found:false,pressed:null});return;}
+      state.target.click();
+      const deadline=Date.now()+4000;
+      const poll=()=>{state=read();if(state.pressed==="true")resolve({found:true,pressed:state.pressed});else if(Date.now()>=deadline)resolve({found:true,pressed:state.pressed});else setTimeout(poll,100);};
+      poll();
+    })`);
+    if (!selectionState.found || selectionState.pressed !== "true") {
+      throw new Error(`Available-reset subscription was not selected: ${JSON.stringify(selectionState)}`);
     }
     await new Promise((resolve) => setTimeout(resolve, Math.max(delayMs, 1_500)));
     return;
@@ -394,6 +414,7 @@ function start() {
 	  action !== "usage-confirm" &&
 	  action !== "usage-confirm-final" &&
 	  action !== "usage-select-second" &&
+	  action !== "usage-select-with-reset" &&
 	  action !== "appshots-open" &&
 	  action !== "appshots-hotkey" &&
 	  action !== "appshots-settings-trigger" &&


### PR DESCRIPTION
## Summary

- add exact, reviewed support for ChatGPT 26.901.22334 build 7746 while retaining the 6396 and 6662 compatibility paths
- preserve every stored subscription row when a child account read times out, while keeping unavailable rows disconnected and fail-closed
- display reset availability with explicit `available_count` semantics plus a compatibility fallback, and keep subscription selection synchronous across the usage UI
- make the wrapper exit promptly on cancellation and recursively sign the nested app helpers used by current builds

## Verification

- `npm run check`
- `npm run release:check`
- `go test -race ./cmd/codex-mux ./internal/mux -count=1`
- focused shutdown regression repeated 20 times
- account continuity regression repeated 10 times
- clean-room build from the exact official build-7746 ASAR; app and nested helpers passed strict code-signature checks
- isolated live control probe retained all stored rows, showed both connected subscriptions, and reported reset availability of 0 and 1 without consuming a reset

The official ChatGPT app is not modified by the router build process.