### PR TITLE
Fix signing team detection for Apple Development identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ CODEX_MUX_SIGNING_IDENTITY="Developer ID Application: Example Corp (TEAMID1234)"
   python3 scripts/patch_app.py
 ```
 
+The patcher resolves the signing team from a temporary signed executable, so
+Apple Development identities whose display-name suffix differs from their team ID
+are supported. `CODEX_MUX_SIGNING_IDENTITY` also accepts a certificate fingerprint.
+
 Reuse the same Apple team for every rebuild. Changing teams changes the app's
 designated requirement and can invalidate existing macOS privacy consent. The
 patcher refuses an unexpected team change unless you deliberately pass

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "check": "npm run check:go && npm run check:js && npm run check:python && npm run check:shell",
     "check:go": "go test ./... && go vet ./...",
     "check:js": "node --check ui/account-menu.js && node --check ui/thread-subscription.js && node --check ui/ui-test-bridge.cjs",
-    "check:python": "python3 -m py_compile scripts/patch_app.py scripts/check_release.py",
+    "check:python": "python3 -m py_compile scripts/patch_app.py scripts/check_release.py && python3 -m unittest discover -s scripts -p \"test_*.py\"",
     "check:shell": "bash -n install.sh",
     "release:check": "python3 scripts/check_release.py"
   },

--- a/scripts/patch_app.py
+++ b/scripts/patch_app.py
@@ -125,12 +125,21 @@ def resolve_signing_identity(allow_adhoc: bool) -> str:
 def signing_team_identifier(identity: str) -> str | None:
     if identity == "-":
         return None
-    match = re.search(r"\(([A-Z0-9]{10})\)$", identity)
-    if match is None:
-        raise RuntimeError(
-            "the signing identity must end with its 10-character Apple team ID"
-        )
-    return match.group(1)
+    # Apple Development display names may end in a person ID, not a team ID.
+    # Let codesign resolve the exact selector (including certificate hashes),
+    # then inspect the team it actually writes without exporting a certificate.
+    with tempfile.TemporaryDirectory(prefix=".codex-mux-signing-probe-") as temporary:
+        probe = Path(temporary) / "signing-probe"
+        shutil.copyfile("/usr/bin/true", probe)
+        run([
+            "codesign", "--force", "--sign", identity,
+            "--timestamp=none", str(probe),
+        ])
+        _, team = signed_code_metadata(probe)
+    if team is None or re.fullmatch(r"[A-Z0-9]{10}", team) is None:
+        raise RuntimeError("could not determine the selected signing identity's Apple team ID")
+    return team
+
 
 
 def signed_code_metadata(path: Path) -> tuple[str | None, str | None]:

--- a/scripts/test_patch_app.py
+++ b/scripts/test_patch_app.py
@@ -1,0 +1,54 @@
+"""Signing regression tests; no signing certificate or macOS tools required."""
+import subprocess
+import unittest
+from unittest import mock
+
+import patch_app
+
+
+class SigningTeamTests(unittest.TestCase):
+    def resolve(self, identity, metadata=("true", "TEAMID5678")):
+        with mock.patch.object(patch_app.shutil, "copyfile") as copy, \
+             mock.patch.object(patch_app, "run") as run, \
+             mock.patch.object(patch_app, "signed_code_metadata", return_value=metadata):
+            result = patch_app.signing_team_identifier(identity)
+        return result, copy, run
+
+    def test_development_name_suffix_is_not_the_team(self):
+        result, copy, run = self.resolve("Apple Development: Example (PERSON1234)")
+        self.assertEqual(result, "TEAMID5678")
+        self.assertEqual(str(copy.call_args.args[0]), "/usr/bin/true")
+        self.assertIn("Apple Development: Example (PERSON1234)", run.call_args.args[0])
+
+    def test_certificate_fingerprint_selector_is_preserved(self):
+        fingerprint = "A" * 40
+        result, _, run = self.resolve(fingerprint)
+        self.assertEqual(result, "TEAMID5678")
+        command = run.call_args.args[0]
+        self.assertEqual(command[command.index("--sign") + 1], fingerprint)
+
+    def test_developer_id_uses_actual_signature_team(self):
+        result, _, _ = self.resolve("Developer ID Application: Example (TEAMID5678)")
+        self.assertEqual(result, "TEAMID5678")
+
+    def test_adhoc_does_not_invoke_signing_tools(self):
+        with mock.patch.object(patch_app, "run") as run, \
+             mock.patch.object(patch_app.shutil, "copyfile") as copy:
+            self.assertIsNone(patch_app.signing_team_identifier("-"))
+        run.assert_not_called()
+        copy.assert_not_called()
+
+    def test_missing_or_invalid_team_fails_closed(self):
+        for team in (None, "not set", "short", "TEAMID5678\nother"):
+            with self.subTest(team=team), self.assertRaises(RuntimeError):
+                self.resolve("Apple Development: Example (PERSON1234)", ("true", team))
+
+    def test_signing_failure_is_not_replaced_by_name_suffix(self):
+        with mock.patch.object(patch_app.shutil, "copyfile"), \
+             mock.patch.object(patch_app, "run", side_effect=subprocess.CalledProcessError(1, "codesign")), \
+             self.assertRaises(subprocess.CalledProcessError):
+            patch_app.signing_team_identifier("Apple Development: Example (PERSON1234)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix installation with Apple Development identities whose display-name suffix is a person ID rather than the signing team ID. Previously, a certificate named `Apple Development: Example (PERSON1234)` could sign successfully with team `TEAMID5678`, but the patcher would expect `PERSON1234` and reject its own output as an unexpected signing team. That inferred ID is also used when preparing team-specific bundle metadata.

Resolve the team by signing a disposable copy of `/usr/bin/true` with the exact selected identity and reading its `TeamIdentifier`. This also supports explicit certificate fingerprint selectors without guessing from a certificate name. The probe is never executed, is removed afterward, and a missing/invalid team or failed signing operation still aborts the build. Ad-hoc signing retains its existing behavior.

Adds six Python regression tests to the existing `check:python` command and documents identity resolution. This is a focused signing fix; it does not change desktop compatibility, runtime versions, account routing, or entitlement policy.

## Verification

- [x] `npm run check`
- [x] `npm run release:check`
- [x] `xcrun clang -fsyntax-only -Wall -Wextra native/launcher.c`
- [x] Regression tests reproduce the name-suffix failure before the fix and pass afterward.
- [x] Real macOS Apple silicon signing probe with both an Apple Development display name and its fingerprint; both resolve the actual team reported by the signed app.
- [ ] Full app rebuild against the exact upstream ASAR recorded in `docs/COMPATIBILITY.md` (not rerun for this isolated PR).
- [x] No credentials, account data, app bundles, certificates, or device codes are included.

## Security-sensitive changes

The patcher performs one additional local `codesign` operation using the already-selected identity, on a temporary executable that is never launched. It reads public signature metadata rather than exporting a certificate or reading private-key material. Existing signing-team continuity checks remain in place. The original app, account state, entitlements, and network/control-service behavior are unchanged.
